### PR TITLE
Remove root folder on deletion

### DIFF
--- a/src/@batch-flask/ui/file/file-navigator/file-navigator.ts
+++ b/src/@batch-flask/ui/file/file-navigator/file-navigator.ts
@@ -263,6 +263,9 @@ export class FileNavigator<TParams = any> {
                     return new Activity(name, initializer);
                 });
             }),
+            tap(() => {
+                this._removeFile(folder);
+            }),
         );
     }
 


### PR DESCRIPTION
Currently the root folder remains after a delete action (e.g. if folder "foo" contains file "bar", right click on "foo" > delete should remove both "foo" and "bar" from the file tree viewer, but currently only removes "bar". This fixes that problem.