### PR TITLE
Internal: Handle release retries by not re-uploading artifact

### DIFF
--- a/scripts/azpipelines/upload-to-storage.js
+++ b/scripts/azpipelines/upload-to-storage.js
@@ -64,7 +64,8 @@ async function uploadToBlob(container, filename, blobName, override = false) {
     try {
         return createBlobFromLocalFile(container, filename, blobName, override);
     } catch (error) {
-        if (error.code === "BlobAlreadyExists" && attemptNumber > 1) {
+        console.log("Error code is", error.code);
+        if (error.code === "BlobAlreadyExists") {
             const blob = await getBlob(container, blobName);
             const md5 = computeFileMd5(filename);
             const blobMd5 = blob.contentSettings && blob.contentSettings.contentMD5;

--- a/scripts/azpipelines/upload-to-storage.js
+++ b/scripts/azpipelines/upload-to-storage.js
@@ -32,7 +32,6 @@ async function getBlob(container, blobName) {
                 return reject(error);
             }
 
-            console.log("Uploaded", result, response);
             resolve(result);
         });
     });
@@ -64,16 +63,14 @@ async function uploadToBlob(container, filename, blobName, override = false) {
     try {
         return await createBlobFromLocalFile(container, filename, blobName, override);
     } catch (error) {
-        console.log("Error code is", error.code);
         if (error.code === "BlobAlreadyExists") {
             const blob = await getBlob(container, blobName);
             const md5 = computeFileMd5(filename);
             const blobMd5 = blob.contentSettings && blob.contentSettings.contentMD5;
-            console.log("Md5", md5, blobMd5);
             if (md5 === blobMd5) {
-                console.log(`Already uploaded ${filename} skipping`);
+                console.log(`Already uploaded ${filename} skipping(Md5 hash matched)`);
             } else {
-                throw new Error("Error blob already exists but doesn't match the local file.");
+                throw new Error(`Error blob already exists but doesn't match the local file. ${md5} != ${blobMd5}`);
             }
         } else {
             throw error;

--- a/scripts/azpipelines/upload-to-storage.js
+++ b/scripts/azpipelines/upload-to-storage.js
@@ -62,7 +62,7 @@ async function createBlobFromLocalFile(container, filename, blobName, override =
 async function uploadToBlob(container, filename, blobName, override = false) {
     console.log(`Uploading ${filename} ====> Container=${container}, Blobname=${blobName}`);
     try {
-        return createBlobFromLocalFile(container, filename, blobName, override);
+        return await createBlobFromLocalFile(container, filename, blobName, override);
     } catch (error) {
         console.log("Error code is", error.code);
         if (error.code === "BlobAlreadyExists") {

--- a/scripts/azpipelines/upload-to-storage.js
+++ b/scripts/azpipelines/upload-to-storage.js
@@ -22,7 +22,7 @@ const blobService = azureStorage.createBlobService(storageAccountName, storageAc
 
 function computeFileMd5(filename) {
     const data = fs.readFileSync(filename);
-    return crypto.createHash("md5").update(data).digest("hex");
+    return crypto.createHash("md5").update(data).digest("base64");
 }
 
 async function getBlob(container, blobName) {
@@ -69,6 +69,7 @@ async function uploadToBlob(container, filename, blobName, override = false) {
             const blob = await getBlob(container, blobName);
             const md5 = computeFileMd5(filename);
             const blobMd5 = blob.contentSettings && blob.contentSettings.contentMD5;
+            console.log("Md5", md5, blobMd5);
             if (md5 === blobMd5) {
                 console.log(`Already uploaded ${filename} skipping`);
             } else {


### PR DESCRIPTION
fix #1689 
This will try the following: 
- Upload the file to blob
- If it fails because blob already exists compare the md5 of the blob with the local file
- If this is the same just pass as the file is already up to date on the blob
- If the file is different throw an error and fail the release(File shouldn't be there or release has wrong version)