### PR TITLE
Auto add default file group output container

### DIFF
--- a/src/app/components/data/shared/file-group-picker/file-group-picker.component.ts
+++ b/src/app/components/data/shared/file-group-picker/file-group-picker.component.ts
@@ -82,21 +82,8 @@ export class FileGroupPickerComponent implements ControlValueAccessor, OnInit, O
                 filter: FilterBuilder.prop("name").startswith(Constants.ncjFileGroupPrefix),
             });
 
-            this.fileGroupsData.fetchAll().subscribe((groups: List<BlobContainer>) => {
+            this.fileGroupsData.fetchAll().subscribe(() => {
                 this._loading = false;
-                // if we have a filegroup that was pre-populated and it doesn't exist in the
-                // collection, then create it.
-                const nameWithPrefix = this.value.value;
-                if (groups && nameWithPrefix && !this._fileGroupExists(nameWithPrefix)) {
-                    const nameWithoutPrefix = this.fileGroupService.removeFileGroupPrefix(nameWithPrefix);
-                    this.fileGroupService.create(nameWithoutPrefix).subscribe({
-                        next: () => {
-                            this.storageContainerService.onContainerAdded.next(nameWithPrefix);
-                        },
-                        error: () => null,
-                    });
-                }
-
                 this._checkValid(this.value.value);
             });
         });
@@ -139,11 +126,7 @@ export class FileGroupPickerComponent implements ControlValueAccessor, OnInit, O
     }
 
     private _checkValid(value: string) {
-        const valid = this._loading || !value || this._fileGroupExists(value);
+        const valid = this._loading || !value || this.fileGroups.map(x => x.name).includes(value);
         this.warning = !valid;
-    }
-
-    private _fileGroupExists(value: string) {
-        return this.fileGroups.map(x => x.name).includes(value);
     }
 }

--- a/src/app/components/data/shared/file-group-picker/file-group-picker.html
+++ b/src/app/components/data/shared/file-group-picker/file-group-picker.html
@@ -1,7 +1,7 @@
 <bl-form-field>
     <input type="text" blInput  [matAutocomplete]="auto" [formControl]="value" [placeholder]="label">
     <bl-hint class="warning" *ngIf="warning">
-        This file group doesn't seem to exist. If you just created it, it will validate when the file group has finished uploading.
+            {{'file-group-picker.warning' | i18n}}
     </bl-hint>
     <bl-hint *ngIf="hint" align="end">
         {{hint}}
@@ -9,7 +9,7 @@
 </bl-form-field>
 <mat-autocomplete #auto="matAutocomplete">
     <mat-option value="" (onSelectionChange)="createFileGroup($event)" class="new-file-group">
-        + Create a new file group
+        + {{'file-group-picker.create' | i18n}}
     </mat-option>
     <mat-option *ngFor="let fileGroup of fileGroups;trackBy: trackFileGroup" [value]="fileGroup.name">
         {{ fileGroup.name }}

--- a/src/app/components/data/shared/file-group-picker/file-group-picker.i18n.yml
+++ b/src/app/components/data/shared/file-group-picker/file-group-picker.i18n.yml
@@ -1,0 +1,3 @@
+file-group-picker:
+  create: Create a new file group
+  warning: This file group doesn't seem to exist. It will be created for you when the job is submitted.

--- a/src/app/components/market/submit/parameter-input/parameter-input.component.spec.ts
+++ b/src/app/components/market/submit/parameter-input/parameter-input.component.spec.ts
@@ -5,10 +5,12 @@ import { By } from "@angular/platform-browser";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { RouterTestingModule } from "@angular/router/testing";
 import { MaterialModule, ServerError } from "@batch-flask/core";
+import { I18nTestingModule } from "@batch-flask/core/testing";
 import { PermissionService, SelectComponent, SelectModule } from "@batch-flask/ui";
 import { ButtonsModule } from "@batch-flask/ui/buttons";
 import { DialogService } from "@batch-flask/ui/dialogs";
 import { FormModule } from "@batch-flask/ui/form";
+import { I18nUIModule } from "@batch-flask/ui/i18n";
 import { SidebarManager } from "@batch-flask/ui/sidebar";
 import { Subject, of, throwError } from "rxjs";
 
@@ -125,6 +127,8 @@ describe("ParameterInputComponent", () => {
                 ButtonsModule,
                 FormModule,
                 FormsModule,
+                I18nTestingModule,
+                I18nUIModule,
                 MaterialModule,
                 NoopAnimationsModule,
                 RouterTestingModule,

--- a/src/app/components/market/submit/submit-ncj-template.component.spec.ts
+++ b/src/app/components/market/submit/submit-ncj-template.component.spec.ts
@@ -20,8 +20,12 @@ import { PoolPickerComponent } from "app/components/job/action/add";
 import { ParameterInputComponent, SubmitNcjTemplateComponent } from "app/components/market/submit";
 import { NcjJobTemplate, NcjParameterRawType, NcjPoolTemplate, NcjTemplateMode, Pool } from "app/models";
 import {
-    NcjFileGroupService, NcjSubmitService,
-    NcjTemplateService, PoolOsService, PoolService,
+    NcjFileGroupService,
+    NcjSubmitService,
+    NcjTemplateService,
+    PoolOsService,
+    PoolService,
+    SettingsService,
     VmSizeService,
 } from "app/services";
 import { AutoStorageService, StorageBlobService, StorageContainerService } from "app/services/storage";
@@ -111,6 +115,7 @@ describe("SubmitNcjTemplateComponent", () => {
     let storageBlobServiceSpy;
     let fileGroupServiceSpy;
     let poolOsServiceSpy;
+    let settingsServiceSpy;
 
     const blendFile = "myscene.blend";
     let queryParameters;
@@ -195,6 +200,13 @@ describe("SubmitNcjTemplateComponent", () => {
                 return `${Constants.ncjFileGroupPrefix}${fgName}`;
             }),
         };
+
+        settingsServiceSpy = {
+            settings: {
+                "job-template.default-output-container": "foo",
+            },
+        };
+
         TestBed.configureTestingModule({
             imports: [
                 RouterTestingModule,
@@ -225,6 +237,7 @@ describe("SubmitNcjTemplateComponent", () => {
                 { provide: StorageBlobService, useValue: storageBlobServiceSpy },
                 { provide: NotificationService, useValue: notificationServiceSpy },
                 { provide: PoolOsService, useValue: poolOsServiceSpy },
+                { provide: SettingsService, useValue: settingsServiceSpy },
             ],
 
             schemas: [NO_ERRORS_SCHEMA],

--- a/src/app/components/market/submit/submit-ncj-template.component.spec.ts
+++ b/src/app/components/market/submit/submit-ncj-template.component.spec.ts
@@ -203,7 +203,7 @@ describe("SubmitNcjTemplateComponent", () => {
 
         settingsServiceSpy = {
             settings: {
-                "job-template.default-output-container": "foo",
+                "job-template.default-output-filegroup": "foo",
             },
         };
 

--- a/src/app/components/market/submit/submit-ncj-template.component.ts
+++ b/src/app/components/market/submit/submit-ncj-template.component.ts
@@ -77,7 +77,7 @@ export class SubmitNcjTemplateComponent implements OnInit, OnChanges, OnDestroy 
         private settingsService: SettingsService) {
 
         this.form = new FormGroup({});
-        this._defaultOutputDataContainer = this.settingsService.settings["job-template.default-output-container"];
+        this._defaultOutputDataContainer = this.settingsService.settings["job-template.default-output-filegroup"];
     }
 
     public ngOnInit() {

--- a/src/app/components/market/submit/submit-ncj-template.component.ts
+++ b/src/app/components/market/submit/submit-ncj-template.component.ts
@@ -15,7 +15,7 @@ import { exists, log } from "@batch-flask/utils";
 import { FileGroupCreateFormComponent } from "app/components/data/action";
 import { NcjJobTemplate, NcjParameter, NcjPoolTemplate, NcjTemplateMode } from "app/models";
 import { FileGroupCreateDto, FileOrDirectoryDto } from "app/models/dtos";
-import { NcjFileGroupService, NcjSubmitService, NcjTemplateService } from "app/services";
+import { NcjFileGroupService, NcjSubmitService, NcjTemplateService, SettingsService } from "app/services";
 import { StorageContainerService } from "app/services/storage";
 import { Constants } from "common";
 import { Subscription, of } from "rxjs";
@@ -62,6 +62,7 @@ export class SubmitNcjTemplateComponent implements OnInit, OnChanges, OnDestroy 
     private _parameterTypeMap = {};
     private _queryParameters: {};
     private _loaded = false;
+    private _defaultOutputDataContainer = null;
 
     constructor(
         private formBuilder: FormBuilder,
@@ -72,9 +73,13 @@ export class SubmitNcjTemplateComponent implements OnInit, OnChanges, OnDestroy 
         private ncjSubmitService: NcjSubmitService,
         private sidebarManager: SidebarManager,
         private fileGroupService: NcjFileGroupService,
-        private storageService: StorageContainerService) {
+        private storageService: StorageContainerService,
+        private settingsService: SettingsService) {
 
         this.form = new FormGroup({});
+        this.settingsService.settingsObs.subscribe((settings) => {
+            this._defaultOutputDataContainer = settings["job-template.default-output-container"];
+        });
     }
 
     public ngOnInit() {
@@ -83,6 +88,7 @@ export class SubmitNcjTemplateComponent implements OnInit, OnChanges, OnDestroy 
             if (!this._loaded) {
                 // subscribe is fired every time a value changes now so don't want to re-apply
                 this._checkForAutoPoolParam();
+                this._checkForOutputContainerParam();
                 this._checkForAssetsToSync();
                 this._applyinitialData();
                 this._loaded = true;
@@ -227,6 +233,16 @@ export class SubmitNcjTemplateComponent implements OnInit, OnChanges, OnDestroy 
                 : NcjTemplateMode.ExistingPoolAndJob;
 
             this.pickMode(modeAutoSelect);
+        }
+    }
+
+    private _checkForOutputContainerParam() {
+        const outputParamKey = Constants.KnownQueryParameters.outputs;
+        const outputContainer = this._queryParameters[outputParamKey];
+        if (!outputContainer && this._defaultOutputDataContainer) {
+            // output file-group parameter was not passed in, but we have one in the default user
+            // settings, so add it to the query parameters.
+            this._queryParameters[outputParamKey] = this._defaultOutputDataContainer;
         }
     }
 

--- a/src/app/components/market/submit/submit-ncj-template.component.ts
+++ b/src/app/components/market/submit/submit-ncj-template.component.ts
@@ -77,9 +77,7 @@ export class SubmitNcjTemplateComponent implements OnInit, OnChanges, OnDestroy 
         private settingsService: SettingsService) {
 
         this.form = new FormGroup({});
-        this.settingsService.settingsObs.subscribe((settings) => {
-            this._defaultOutputDataContainer = settings["job-template.default-output-container"];
-        });
+        this._defaultOutputDataContainer = this.settingsService.settings["job-template.default-output-container"];
     }
 
     public ngOnInit() {

--- a/src/app/components/settings/default-settings.json
+++ b/src/app/components/settings/default-settings.json
@@ -33,5 +33,9 @@
   // Which channel to use for auto update. Can be:
   //  - stable: Recommended
   //  - insider: This is the latest build from master. Use at your own risk.
-  "update.channel": null
+  "update.channel": null,
+
+  // Default file group container to use when submitting Gallery template jobs.
+  // Don't include the 'fgrp-' file group prefix
+  "job-template.default-output-container": null
 }

--- a/src/app/components/settings/default-settings.json
+++ b/src/app/components/settings/default-settings.json
@@ -37,5 +37,5 @@
 
   // Default file group container to use when submitting Gallery template jobs.
   // Don't include the 'fgrp-' file group prefix
-  "job-template.default-output-container": null
+  "job-template.default-output-filegroup": null
 }

--- a/src/app/models/settings.ts
+++ b/src/app/models/settings.ts
@@ -15,5 +15,5 @@ export interface Settings {
     "github-data.source.branch": string;
     "github-data.source.repo": string;
     "update.channel": string;
-    "job-template.default-output-container": string;
+    "job-template.default-output-filegroup": string;
 }

--- a/src/app/models/settings.ts
+++ b/src/app/models/settings.ts
@@ -15,4 +15,5 @@ export interface Settings {
     "github-data.source.branch": string;
     "github-data.source.repo": string;
     "update.channel": string;
+    "job-template.default-output-container": string;
 }

--- a/src/common/constants/constants.ts
+++ b/src/common/constants/constants.ts
@@ -211,6 +211,7 @@ export const KnownQueryParameters = {
     inputParameter: "input-parameter",
     assetContainer: "asset-container",
     assetPaths: "asset-paths",
+    outputs: "outputs",
 };
 
 const cdn = "https://batchexplorer.azureedge.net";


### PR DESCRIPTION
User can define a default output container to use when submitting gallery template jobs. Handles one being passed in from a plugin using the ms-batchlabs:// route parameters also.

Fix: #1790
