### PR TITLE
Fix: Show the right icon in insider builds

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -29,7 +29,7 @@ protocols:
 
 # Mac OS configuration
 mac:
-  icon: "app/assets/images/icon.icns"
+  icon: "src/app/assets/images/icon.icns"
 
 # Config for OSX dmg
 dmg:
@@ -43,7 +43,7 @@ dmg:
 
 # Windows configuration
 win:
-  icon: "app/assets/images/icon.ico"
+  icon: "src/app/assets/images/icon.ico"
   target:
     - "zip"
     - "nsis"


### PR DESCRIPTION
fix #1793 