### PR TITLE
Fix: Authentication error is being cached an doesn't allow reload 

### DIFF
--- a/src/app/services/adal/adal.service.ts
+++ b/src/app/services/adal/adal.service.ts
@@ -86,6 +86,9 @@ export class AdalService implements OnDestroy {
             this.tokenCache.storeToken(tenantId, resource, token);
             delete this._waitingPromises[key];
             return token;
+        }).catch((e) =>  {
+            delete this._waitingPromises[key];
+            return Promise.reject(e);
         });
         this._waitingPromises[key] = promise;
         return promise;

--- a/src/client/core/aad/adal/aad.service.spec.ts
+++ b/src/client/core/aad/adal/aad.service.spec.ts
@@ -1,7 +1,6 @@
 import { AccessToken, InMemoryDataStore } from "@batch-flask/core";
 import { Constants } from "common";
 import { DateTime } from "luxon";
-import { F } from "test/utils";
 import { MockBrowserWindow, MockSplashScreen } from "test/utils/mocks/windows";
 import { AADUser } from "./aad-user";
 import { AADService } from "./aad.service";
@@ -107,7 +106,7 @@ describe("AADService", () => {
             (service as any)._userDecoder.decode = decodeSpy;
         });
 
-        it("should use the cached token if not expired", F(async () => {
+        it("should use the cached token if not expired", async () => {
             (service as any)._tokenCache.storeToken(tenant1, resource1, new AccessToken({
                 access_token: "initialtoken",
                 expires_on: DateTime.local().plus({ hours: 1 }),
@@ -115,9 +114,9 @@ describe("AADService", () => {
             token = await service.accessTokenData(tenant1, resource1);
             expect(token).not.toBeNull();
             expect(token.access_token).toEqual("initialtoken");
-        }));
+        });
 
-        it("should reload a new token if the token is expiring before the safe margin", F(async () => {
+        it("should reload a new token if the token is expiring before the safe margin", async () => {
             (service as any)._tokenCache.storeToken(tenant1, resource1, new AccessToken({
                 access_token: "initialtoken",
                 expires_on: DateTime.local().plus({ minutes: 1 }).toJSDate(),
@@ -130,7 +129,7 @@ describe("AADService", () => {
 
             expect(token).not.toBeNull();
             expect(token.access_token).toEqual("refreshedToken");
-        }));
+        });
 
         it("should load a new token if getting a token for another resource", async (done) => {
             (service as any)._tokenCache.storeToken(tenant1, resource1, new AccessToken({

--- a/src/common/deferred/deferred.spec.ts
+++ b/src/common/deferred/deferred.spec.ts
@@ -1,8 +1,7 @@
 import { Deferred } from "common";
-import { F } from "test/utils";
 
 describe("Deferred", () => {
-    it("succeed", F(() => {
+    it("succeed", () => {
         const deferred = new Deferred();
 
         const promise = deferred.promise.then((value) => {
@@ -11,9 +10,9 @@ describe("Deferred", () => {
 
         deferred.resolve("resolved-value");
         return promise;
-    }));
+    });
 
-    it("pass error", F(() => {
+    it("pass error", () => {
         const deferred = new Deferred();
 
         const promise = deferred.promise.then(() => {
@@ -24,5 +23,5 @@ describe("Deferred", () => {
 
         deferred.reject("rejected-error");
         return promise;
-    }));
+    });
 });

--- a/src/test/utils/async-test.ts
+++ b/src/test/utils/async-test.ts
@@ -1,1 +1,0 @@
-export const F = f => done => f().then(done).catch(done.fail);

--- a/src/test/utils/index.ts
+++ b/src/test/utils/index.ts
@@ -1,1 +1,0 @@
-export * from "./async-test";


### PR DESCRIPTION
fix #1505
This should allow to recover after the connection died while retrieving tokens.

This was discovered after the original issue was the auth window was failing to load the AADlogin page and then never resolving which was fixed. Now though that it is throwing an error it was being cached by mistake