### PR TITLE
Fix: Voice over issue in credentials and code samples

### DIFF
--- a/src/@batch-flask/ui/buttons/button.component.ts
+++ b/src/@batch-flask/ui/buttons/button.component.ts
@@ -107,7 +107,7 @@ export class ButtonComponent extends ClickableComponent {
 
     @HostListener("focus")
     public showTooltip() {
-        this._tooltip.show();
+        this._tooltip.show(100);
     }
 
     @HostListener("blur")


### PR DESCRIPTION
Seems like showing the tooltip immediatly conflict with the label and Voice Over describe weird things