### PR TITLE
Fix: Pool graph doesn't let you pick one week

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug fixes
 * Job schedule with autopool fail to display [\#1995](https://github.com/Azure/BatchExplorer/issues/1995)
+* Pool graphs One Day and One Week option both have value of 1 day [\#1999](https://github.com/Azure/BatchExplorer/issues/1999)
 
 # 2.0.2
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "name": "Microsoft Corporation",
     "email": "tiguerin@microsoft.com"
   },
-  "version": "2.0.2",
+  "version": "2.0.3",
   "main": "build/client/main.prod.js",
   "scripts": {
     "ts": "ts-node --project tsconfig.node.json --files",

--- a/src/app/components/pool/graphs/pool-graphs.html
+++ b/src/app/components/pool/graphs/pool-graphs.html
@@ -93,7 +93,7 @@
                 <bl-option [value]="historyLength.TenMinute" [label]="'pool-graphs.timespan.10min' | i18n"></bl-option>
                 <bl-option [value]="historyLength.OneHour" [label]="'pool-graphs.timespan.1h' | i18n"></bl-option>
                 <bl-option [value]="historyLength.OnDay" [label]="'pool-graphs.timespan.24h' | i18n"></bl-option>
-                <bl-option [value]="historyLength.OnDay" [label]="'pool-graphs.timespan.7d' | i18n"></bl-option>
+                <bl-option [value]="historyLength.OnWeek" [label]="'pool-graphs.timespan.7d' | i18n"></bl-option>
             </bl-select>
         </div>
     </div>


### PR DESCRIPTION
One week and a day both have the value of a day

fix #1999 