### PR TITLE
Update auto-user defaults to target pool scope

### DIFF
--- a/src/app/components/task/base/user-identity/user-identity-picker.component.spec.ts
+++ b/src/app/components/task/base/user-identity/user-identity-picker.component.spec.ts
@@ -56,32 +56,33 @@ describe("UserIdentityComponent", () => {
         expect(options[1].value).toEqual({
             username: "bar",
         });
-        expect(options[2].label).toEqual("Task user");
-        expect(options[2].value).toEqual({
-            autoUser: {
-                elevationLevel: UserAccountElevationLevel.nonadmin,
-                scope: AutoUserScope.task,
-            },
-        });
-        expect(options[3].label).toEqual("Task user (Admin)");
+
+        expect(options[3].label).toEqual("Pool user");
         expect(options[3].value).toEqual({
             autoUser: {
-                elevationLevel: UserAccountElevationLevel.admin,
-                scope: AutoUserScope.task,
-            },
-        });
-        expect(options[4].label).toEqual("Pool user");
-        expect(options[4].value).toEqual({
-            autoUser: {
                 elevationLevel: UserAccountElevationLevel.nonadmin,
                 scope: AutoUserScope.pool,
             },
         });
-        expect(options[5].label).toEqual("Pool user (Admin)");
-        expect(options[5].value).toEqual({
+        expect(options[4].label).toEqual("Pool user (Admin)");
+        expect(options[4].value).toEqual({
             autoUser: {
                 elevationLevel: UserAccountElevationLevel.admin,
                 scope: AutoUserScope.pool,
+            },
+        });
+        expect(options[5].label).toEqual("Task user");
+        expect(options[5].value).toEqual({
+            autoUser: {
+                elevationLevel: UserAccountElevationLevel.nonadmin,
+                scope: AutoUserScope.task,
+            },
+        });
+        expect(options[6].label).toEqual("Task user (Admin)");
+        expect(options[6].value).toEqual({
+            autoUser: {
+                elevationLevel: UserAccountElevationLevel.admin,
+                scope: AutoUserScope.task,
             },
         });
     });

--- a/src/app/components/task/base/user-identity/user-identity-picker.component.spec.ts
+++ b/src/app/components/task/base/user-identity/user-identity-picker.component.spec.ts
@@ -57,29 +57,29 @@ describe("UserIdentityComponent", () => {
             username: "bar",
         });
 
-        expect(options[3].label).toEqual("Pool user");
-        expect(options[3].value).toEqual({
+        expect(options[2].label).toEqual("Pool user");
+        expect(options[2].value).toEqual({
             autoUser: {
                 elevationLevel: UserAccountElevationLevel.nonadmin,
                 scope: AutoUserScope.pool,
             },
         });
-        expect(options[4].label).toEqual("Pool user (Admin)");
-        expect(options[4].value).toEqual({
+        expect(options[3].label).toEqual("Pool user (Admin)");
+        expect(options[3].value).toEqual({
             autoUser: {
                 elevationLevel: UserAccountElevationLevel.admin,
                 scope: AutoUserScope.pool,
             },
         });
-        expect(options[5].label).toEqual("Task user");
-        expect(options[5].value).toEqual({
+        expect(options[4].label).toEqual("Task user");
+        expect(options[4].value).toEqual({
             autoUser: {
                 elevationLevel: UserAccountElevationLevel.nonadmin,
                 scope: AutoUserScope.task,
             },
         });
-        expect(options[6].label).toEqual("Task user (Admin)");
-        expect(options[6].value).toEqual({
+        expect(options[5].label).toEqual("Task user (Admin)");
+        expect(options[5].value).toEqual({
             autoUser: {
                 elevationLevel: UserAccountElevationLevel.admin,
                 scope: AutoUserScope.task,
@@ -96,7 +96,7 @@ describe("UserIdentityComponent", () => {
         expect(testComponent.control.value).toEqual({
             autoUser: {
                 elevationLevel: UserAccountElevationLevel.admin,
-                scope: AutoUserScope.task,
+                scope: AutoUserScope.pool,
             },
         });
     });
@@ -135,7 +135,7 @@ describe("UserIdentityComponent", () => {
         expect([...select.selected].first()).toEqual({
             autoUser: {
                 elevationLevel: UserAccountElevationLevel.nonadmin,
-                scope: AutoUserScope.task,
+                scope: AutoUserScope.pool,
             },
         });
     });

--- a/src/app/components/task/base/user-identity/user-identity-picker.component.ts
+++ b/src/app/components/task/base/user-identity/user-identity-picker.component.ts
@@ -14,16 +14,6 @@ interface UserOption {
 
 const defaultUsers = [
     {
-        label: "Task user",
-        scope: AutoUserScope.task,
-        elevationLevel: UserAccountElevationLevel.nonadmin,
-    },
-    {
-        label: "Task user (Admin)",
-        scope: AutoUserScope.task,
-        elevationLevel: UserAccountElevationLevel.admin,
-    },
-    {
         label: "Pool user",
         scope: AutoUserScope.pool,
         elevationLevel: UserAccountElevationLevel.nonadmin,
@@ -31,6 +21,16 @@ const defaultUsers = [
     {
         label: "Pool user (Admin)",
         scope: AutoUserScope.pool,
+        elevationLevel: UserAccountElevationLevel.admin,
+    },
+    {
+        label: "Task user",
+        scope: AutoUserScope.task,
+        elevationLevel: UserAccountElevationLevel.nonadmin,
+    },
+    {
+        label: "Task user (Admin)",
+        scope: AutoUserScope.task,
         elevationLevel: UserAccountElevationLevel.admin,
     },
 ].map(({ label, scope, elevationLevel }) => {


### PR DESCRIPTION
Switch defaults around, to align with best practices (even though default through REST is different)