### PR TITLE
Fix resize error text getting cutoff in banner

### DIFF
--- a/src/app/components/pool/details/error-display/pool-error-display.html
+++ b/src/app/components/pool/details/error-display/pool-error-display.html
@@ -1,40 +1,33 @@
 <div *ngIf="pool">
     <div *ngFor="let resizeError of pool.resizeErrors;trackBy: trackResizeError" [ngSwitch]="resizeError.code">
-        <bl-banner *ngSwitchCase="ResizeErrorCode.accountCoreQuotaReached" fixMessage="Increase quota" [fix]="increaseQuota">
+        <bl-banner *ngSwitchCase="ResizeErrorCode.accountCoreQuotaReached" fixMessage="Increase quota"
+            [fix]="increaseQuota">
             <div [other-fix]="fixStopResizeError" fixMessage="Rescale"></div>
             <div code>{{resizeError.code}}</div>
-            <span message>{{resizeError.message}} ({{dedicatedQuota | async}} cores)</span>
-            <div details>
-                <span>{{resizeError.message}} ({{dedicatedQuota | async}} cores)</span>
-                <div *ngIf="resizeError.values !== 0">
-                    <div *ngFor="let entry of resizeError.values;trackBy: trackErrorValue">
-                        <div>{{entry.key}}: {{entry.value}}</div>
-                    </div>
+            <span title="{{resizeError.message}} ({{dedicatedQuota | async}} cores)" message>{{resizeError.message}} ({{dedicatedQuota | async}} cores)</span>
+            <div details *ngIf="resizeError.values !== 0">
+                <div *ngFor="let entry of resizeError.values;trackBy: trackErrorValue">
+                    <div>{{entry.key}}: {{entry.value}}</div>
                 </div>
             </div>
         </bl-banner>
-        <bl-banner *ngSwitchCase="ResizeErrorCode.accountLowPriorityCoreQuotaReached" fixMessage="Increase quota" [fix]="increaseQuota">
+        <bl-banner *ngSwitchCase="ResizeErrorCode.accountLowPriorityCoreQuotaReached" fixMessage="Increase quota"
+            [fix]="increaseQuota">
             <div [other-fix]="fixStopResizeError" fixMessage="Rescale"></div>
             <div code>{{resizeError.code}}</div>
-            <span message>{{resizeError.message}} ({{lowPriorityQuota | async}} cores)</span>
-            <div details>
-            <span>{{resizeError.message}} ({{lowPriorityQuota | async}} cores)</span>
-                <div *ngIf="resizeError.values !== 0">
-                    <div *ngFor="let entry of resizeError.values;trackBy: trackErrorValue">
-                        <div>{{entry.key}}: {{entry.value}}</div>
-                    </div>
+            <span title="{{resizeError.message}} ({{lowPriorityQuota | async}} cores)" message>{{resizeError.message}} ({{lowPriorityQuota | async}} cores)</span>
+            <div details *ngIf="resizeError.values !== 0">
+                <div *ngFor="let entry of resizeError.values;trackBy: trackErrorValue">
+                    <div>{{entry.key}}: {{entry.value}}</div>
                 </div>
             </div>
         </bl-banner>
         <bl-banner *ngSwitchDefault fixMessage="Rescale" [fix]="fixStopResizeError">
             <div code>{{resizeError.code}}</div>
-            <span message>{{resizeError.message}}</span>
-            <div details>
-                <span>{{resizeError.message}}</span>
-                <div *ngIf="resizeError.values.size !== 0">
-                    <div *ngFor="let entry of resizeError.values;trackBy: trackErrorValue">
-                        <div>{{entry.key}}: {{entry.value}}</div>
-                    </div>
+            <span title="{{resizeError.message}}" message>{{resizeError.message}}</span>
+            <div details *ngIf="resizeError.values.size !== 0">
+                <div *ngFor="let entry of resizeError.values;trackBy: trackErrorValue">
+                    <div>{{entry.key}}: {{entry.value}}</div>
                 </div>
             </div>
         </bl-banner>

--- a/src/app/components/pool/details/error-display/pool-error-display.html
+++ b/src/app/components/pool/details/error-display/pool-error-display.html
@@ -3,29 +3,38 @@
         <bl-banner *ngSwitchCase="ResizeErrorCode.accountCoreQuotaReached" fixMessage="Increase quota" [fix]="increaseQuota">
             <div [other-fix]="fixStopResizeError" fixMessage="Rescale"></div>
             <div code>{{resizeError.code}}</div>
-            <div message>{{resizeError.message}} ({{dedicatedQuota | async}} cores)</div>
-            <div details *ngIf="resizeError.values !== 0">
-                <div *ngFor="let entry of resizeError.values;trackBy: trackErrorValue">
-                    <div>{{entry.key}}: {{entry.value}}</div>
+            <span message>{{resizeError.message}} ({{dedicatedQuota | async}} cores)</span>
+            <div details>
+                <span>{{resizeError.message}} ({{dedicatedQuota | async}} cores)</span>
+                <div *ngIf="resizeError.values !== 0">
+                    <div *ngFor="let entry of resizeError.values;trackBy: trackErrorValue">
+                        <div>{{entry.key}}: {{entry.value}}</div>
+                    </div>
                 </div>
             </div>
         </bl-banner>
         <bl-banner *ngSwitchCase="ResizeErrorCode.accountLowPriorityCoreQuotaReached" fixMessage="Increase quota" [fix]="increaseQuota">
             <div [other-fix]="fixStopResizeError" fixMessage="Rescale"></div>
             <div code>{{resizeError.code}}</div>
-            <div message>{{resizeError.message}} ({{lowPriorityQuota | async}} cores)</div>
-            <div details *ngIf="resizeError.values !== 0">
-                <div *ngFor="let entry of resizeError.values;trackBy: trackErrorValue">
-                    <div>{{entry.key}}: {{entry.value}}</div>
+            <span message>{{resizeError.message}} ({{lowPriorityQuota | async}} cores)</span>
+            <div details>
+            <span>{{resizeError.message}} ({{lowPriorityQuota | async}} cores)</span>
+                <div *ngIf="resizeError.values !== 0">
+                    <div *ngFor="let entry of resizeError.values;trackBy: trackErrorValue">
+                        <div>{{entry.key}}: {{entry.value}}</div>
+                    </div>
                 </div>
             </div>
         </bl-banner>
         <bl-banner *ngSwitchDefault fixMessage="Rescale" [fix]="fixStopResizeError">
             <div code>{{resizeError.code}}</div>
-            <div message>{{resizeError.message}}</div>
-            <div details *ngIf="resizeError.values.size !== 0">
-                <div *ngFor="let entry of resizeError.values;trackBy: trackErrorValue">
-                    <div>{{entry.key}}: {{entry.value}}</div>
+            <span message>{{resizeError.message}}</span>
+            <div details>
+                <span>{{resizeError.message}}</span>
+                <div *ngIf="resizeError.values.size !== 0">
+                    <div *ngFor="let entry of resizeError.values;trackBy: trackErrorValue">
+                        <div>{{entry.key}}: {{entry.value}}</div>
+                    </div>
                 </div>
             </div>
         </bl-banner>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18502617/61554751-8d674780-aa12-11e9-9684-a046467a62de.png)

========>>

![image](https://user-images.githubusercontent.com/18502617/61554788-9ce69080-aa12-11e9-9f0d-a7ae02d27234.png)

Don't love the duplication but its either this or hover text, but hover text may have some accessibility concerns? I guess the message could also just be moved to entirely be in the description so only code + fix in banner