### PR TITLE
Unusable Node Error Banner on Pool Page

### DIFF
--- a/src/app/components/pool/graphs/heatmap/nodes-heatmap.component.spec.ts
+++ b/src/app/components/pool/graphs/heatmap/nodes-heatmap.component.spec.ts
@@ -144,7 +144,7 @@ describe("NodesHeatmapComponent", () => {
             const title = group.select("title");
 
             expect(title).not.toBeFalsy("Should have a rect in bg");
-            expect(title.text()).toContain("2 tasks running on this node");
+            expect(title.text()).toContain("2 tasks running on node");
         });
     });
 

--- a/src/app/components/pool/graphs/heatmap/nodes-heatmap.component.ts
+++ b/src/app/components/pool/graphs/heatmap/nodes-heatmap.component.ts
@@ -343,7 +343,7 @@ export class NodesHeatmapComponent implements AfterViewInit, OnChanges, OnDestro
         titleNode.text((tile) => {
             const count = tile.node.runningTasksCount;
             if (tile.node.state === NodeState.unusable) {
-                return `Error: Unusable Node (${tile.node.id})`;
+                return `Error: Unusable state on node (${tile.node.id})`;
             } else if (tile.node.state === NodeState.startTaskFailed) {
                 return `Error: StartTaskFailed (${tile.node.id})`;
             } else if (tile.node.state === NodeState.unknown) {

--- a/src/app/components/pool/graphs/heatmap/nodes-heatmap.component.ts
+++ b/src/app/components/pool/graphs/heatmap/nodes-heatmap.component.ts
@@ -347,7 +347,7 @@ export class NodesHeatmapComponent implements AfterViewInit, OnChanges, OnDestro
             } else if (tile.node.state === NodeState.startTaskFailed) {
                 return `Error: Start task failed on node (${tile.node.id})`;
             } else if (tile.node.state === NodeState.unknown) {
-                return `Error: Unknown (${tile.node.id})`;
+                return `Error: Unknown state on node (${tile.node.id})`;
             } else {
                 return `${count} tasks running on this node (${tile.node.id})`;
             }

--- a/src/app/components/pool/graphs/heatmap/nodes-heatmap.component.ts
+++ b/src/app/components/pool/graphs/heatmap/nodes-heatmap.component.ts
@@ -349,7 +349,7 @@ export class NodesHeatmapComponent implements AfterViewInit, OnChanges, OnDestro
             } else if (tile.node.state === NodeState.unknown) {
                 return `Error: Unknown state on node (${tile.node.id})`;
             } else {
-                return `${count} tasks running on this node (${tile.node.id})`;
+                return `${count} tasks running on node (${tile.node.id})`;
             }
        });
     }

--- a/src/app/components/pool/graphs/heatmap/nodes-heatmap.component.ts
+++ b/src/app/components/pool/graphs/heatmap/nodes-heatmap.component.ts
@@ -331,11 +331,27 @@ export class NodesHeatmapComponent implements AfterViewInit, OnChanges, OnDestro
         return array;
     }
 
+    /**
+     * Display either how many tasks are running on a given node or an error code if the node errors.
+     * @param Selection object
+     *
+     * If the nodes are in an error state, it will return show a tooltip with the error state and the node id.
+     * If the nodes are not in an error state, it will show the number of tasks running on the node and the
+     * node id.
+     */
     private _displayTileTooltip(titleNode) {
         titleNode.text((tile) => {
             const count = tile.node.runningTasksCount;
-            return `${count} tasks running on this node (${tile.node.id})`;
-        });
+            if (tile.node.state === NodeState.unusable) {
+                return `Error: Unusable Node (${tile.node.id})`;
+            } else if (tile.node.state === NodeState.startTaskFailed) {
+                return `Error: StartTaskFailed (${tile.node.id})`;
+            } else if (tile.node.state === NodeState.unknown) {
+                return `Error: Unknown (${tile.node.id})`;
+            } else {
+                return `${count} tasks running on this node (${tile.node.id})`;
+            }
+       });
     }
 
     private _getTaskHeight(tileSize: number, node: Node) {

--- a/src/app/components/pool/graphs/heatmap/nodes-heatmap.component.ts
+++ b/src/app/components/pool/graphs/heatmap/nodes-heatmap.component.ts
@@ -345,7 +345,7 @@ export class NodesHeatmapComponent implements AfterViewInit, OnChanges, OnDestro
             if (tile.node.state === NodeState.unusable) {
                 return `Error: Unusable state on node (${tile.node.id})`;
             } else if (tile.node.state === NodeState.startTaskFailed) {
-                return `Error: StartTaskFailed (${tile.node.id})`;
+                return `Error: Start task failed on node (${tile.node.id})`;
             } else if (tile.node.state === NodeState.unknown) {
                 return `Error: Unknown (${tile.node.id})`;
             } else {

--- a/src/app/components/pool/graphs/pool-graphs.component.ts
+++ b/src/app/components/pool/graphs/pool-graphs.component.ts
@@ -54,6 +54,7 @@ export class PoolGraphsComponent implements OnChanges, OnDestroy {
     public tasks: List<Task> = List([]);
 
     public startTaskFailedError: any;
+    public unusableNodeError: any;
     public isPaasPool: boolean = false;
     public hasGPU: boolean = false;
 
@@ -176,15 +177,38 @@ export class PoolGraphsComponent implements OnChanges, OnDestroy {
 
         return from(window.domReady);
     }
+
     private _scanForProblems() {
-        const failedNodes = this._stateCounter.get(NodeState.startTaskFailed).getValue();
+        const failedStartTaskNodes = this._stateCounter.get(NodeState.startTaskFailed).getValue();
+        const failedUnusableNodes = this._stateCounter.get(NodeState.unusable).getValue();
         const nodeCount = this.nodes.size;
-        if (nodeCount > 0 && (failedNodes > 10 || failedNodes / nodeCount > 0.3)) {
-            this.startTaskFailedError = {
-                failedNodes, nodeCount,
-            };
+
+        if (nodeCount > 0) {
+            const isStartTaskError: Boolean = failedStartTaskNodes > 10 || failedStartTaskNodes / nodeCount > 0.3;
+            const isUnusableError: Boolean = failedUnusableNodes > 10 || failedUnusableNodes / nodeCount > 0.3;
+
+            if (isStartTaskError && isUnusableError) {
+                this.startTaskFailedError = {
+                    failedStartTaskNodes, nodeCount,
+                };
+                this.unusableNodeError = {
+                    failedUnusableNodes, nodeCount,
+                };
+            } else if (isUnusableError) {
+                this.unusableNodeError = {
+                    failedUnusableNodes, nodeCount,
+                };
+            } else if (isStartTaskError) {
+                this.startTaskFailedError = {
+                    failedStartTaskNodes, nodeCount,
+                };
+            } else {
+                this.startTaskFailedError = null;
+                this.unusableNodeError = null;
+            }
         } else {
             this.startTaskFailedError = null;
+            this.unusableNodeError = null;
         }
     }
 

--- a/src/app/components/pool/graphs/pool-graphs.component.ts
+++ b/src/app/components/pool/graphs/pool-graphs.component.ts
@@ -191,7 +191,6 @@ export class PoolGraphsComponent implements OnChanges, OnDestroy {
             this.startTaskFailedError = null;
             this.unusableNodeError = null;
         } else {
-
             if (isStartTaskError && !isUnusableError) {
                 this.startTaskFailedError = {
                     failedStartTaskNodes, nodeCount,

--- a/src/app/components/pool/graphs/pool-graphs.component.ts
+++ b/src/app/components/pool/graphs/pool-graphs.component.ts
@@ -181,34 +181,33 @@ export class PoolGraphsComponent implements OnChanges, OnDestroy {
     private _scanForProblems() {
         const failedStartTaskNodes = this._stateCounter.get(NodeState.startTaskFailed).getValue();
         const failedUnusableNodes = this._stateCounter.get(NodeState.unusable).getValue();
+
         const nodeCount = this.nodes.size;
 
-        if (nodeCount > 0) {
-            const isStartTaskError: Boolean = failedStartTaskNodes > 10 || failedStartTaskNodes / nodeCount > 0.3;
-            const isUnusableError: Boolean = failedUnusableNodes > 10 || failedUnusableNodes / nodeCount > 0.3;
+        const isStartTaskError: Boolean = failedStartTaskNodes > 10 || failedStartTaskNodes / nodeCount > 0.3;
+        const isUnusableError: Boolean = failedUnusableNodes > 10 || failedUnusableNodes / nodeCount > 0.3;
 
-            if (isStartTaskError && isUnusableError) {
-                this.startTaskFailedError = {
-                    failedStartTaskNodes, nodeCount,
-                };
-                this.unusableNodeError = {
-                    failedUnusableNodes, nodeCount,
-                };
-            } else if (isUnusableError) {
-                this.unusableNodeError = {
-                    failedUnusableNodes, nodeCount,
-                };
-            } else if (isStartTaskError) {
-                this.startTaskFailedError = {
-                    failedStartTaskNodes, nodeCount,
-                };
-            } else {
-                this.startTaskFailedError = null;
-                this.unusableNodeError = null;
-            }
-        } else {
+        if ((!isStartTaskError && !isUnusableError) || nodeCount <= 0) {
             this.startTaskFailedError = null;
             this.unusableNodeError = null;
+        } else {
+
+            if (isStartTaskError && !isUnusableError) {
+                this.startTaskFailedError = {
+                    failedStartTaskNodes, nodeCount,
+                };
+            } else if (!isStartTaskError && isUnusableError) {
+                this.unusableNodeError = {
+                    failedUnusableNodes, nodeCount,
+                };
+            } else {
+                this.startTaskFailedError = {
+                    failedStartTaskNodes, nodeCount,
+                };
+                this.unusableNodeError = {
+                    failedUnusableNodes, nodeCount,
+                };
+            }
         }
     }
 

--- a/src/app/components/pool/graphs/pool-graphs.html
+++ b/src/app/components/pool/graphs/pool-graphs.html
@@ -1,11 +1,15 @@
-<bl-banner *ngIf="startTaskFailedError" fixMessage="Edit the start task" [fix]="openEditStartTask">
-    <div message>The start task has failed on {{startTaskFailedError.failedStartTaskNodes}} out of {{startTaskFailedError.nodeCount}} nodes.</div>
-    <div [other-fix]="rebootFailedNodes" fixMessage="Reboot failed nodes"></div>
-    <div *ngIf="isPaasPool" [other-fix]="reimageFailedNodes" fixMessage="Reimage failed nodes"></div>
-</bl-banner>
-<bl-banner *ngIf="unusableNodeError">
-    <div message>{{unusableNodeError.failedUnusableNodes}} out of {{unusableNodeError.nodeCount}} nodes are in an unusable state.</div>
-</bl-banner>
+<div>
+    <bl-banner *ngIf="startTaskFailedError" fixMessage="Edit the start task" [fix]="openEditStartTask">
+        <div message>The start task has failed on {{startTaskFailedError.failedStartTaskNodes}} out of {{startTaskFailedError.nodeCount}} nodes.</div>
+        <div [other-fix]="rebootFailedNodes" fixMessage="Reboot failed nodes"></div>
+        <div *ngIf="isPaasPool" [other-fix]="reimageFailedNodes" fixMessage="Reimage failed nodes"></div>
+    </bl-banner>
+    <bl-banner *ngIf="unusableNodeError">
+        <div message>{{unusableNodeError.failedUnusableNodes}} out of {{unusableNodeError.nodeCount}} nodes are in an unusable state.
+            Please click nodes for more details.
+        </div>
+    </bl-banner>
+</div>
 <bl-metrics-monitor class="graphs-container">
     <!-- Only show the heatmap, available nodes and running tasks on the pool -->
     <ng-container *ngIf="!node">

--- a/src/app/components/pool/graphs/pool-graphs.html
+++ b/src/app/components/pool/graphs/pool-graphs.html
@@ -1,8 +1,12 @@
 <bl-banner *ngIf="startTaskFailedError" fixMessage="Edit the start task" [fix]="openEditStartTask">
     <div message>It seems like the start task is failing on many nodes.
-        ({{startTaskFailedError.failedNodes}}/{{startTaskFailedError.nodeCount}})</div>
+        ({{startTaskFailedError.failedStartTaskNodes}}/{{startTaskFailedError.nodeCount}})</div>
     <div [other-fix]="rebootFailedNodes" fixMessage="Reboot failed nodes"></div>
     <div *ngIf="isPaasPool" [other-fix]="reimageFailedNodes" fixMessage="Reimage failed nodes"></div>
+</bl-banner>
+<bl-banner *ngIf="unusableNodeError">
+    <div message>It seems like many nodes are unusable.
+        ({{unusableNodeError.failedUnusableNodes}}/{{unusableNodeError.nodeCount}})</div>
 </bl-banner>
 <bl-metrics-monitor class="graphs-container">
     <!-- Only show the heatmap, available nodes and running tasks on the pool -->

--- a/src/app/components/pool/graphs/pool-graphs.html
+++ b/src/app/components/pool/graphs/pool-graphs.html
@@ -1,12 +1,10 @@
 <bl-banner *ngIf="startTaskFailedError" fixMessage="Edit the start task" [fix]="openEditStartTask">
-    <div message>It seems like the start task is failing on many nodes.
-        ({{startTaskFailedError.failedStartTaskNodes}}/{{startTaskFailedError.nodeCount}})</div>
+    <div message>It seems like the start task is failing on {{startTaskFailedError.failedStartTaskNodes}} out of {{startTaskFailedError.nodeCount}} nodes.</div>
     <div [other-fix]="rebootFailedNodes" fixMessage="Reboot failed nodes"></div>
     <div *ngIf="isPaasPool" [other-fix]="reimageFailedNodes" fixMessage="Reimage failed nodes"></div>
 </bl-banner>
 <bl-banner *ngIf="unusableNodeError">
-    <div message>It seems like many nodes are unusable.
-        ({{unusableNodeError.failedUnusableNodes}}/{{unusableNodeError.nodeCount}})</div>
+    <div message>It seems like {{unusableNodeError.failedUnusableNodes}} out of {{unusableNodeError.nodeCount}} nodes are unusable.</div>
 </bl-banner>
 <bl-metrics-monitor class="graphs-container">
     <!-- Only show the heatmap, available nodes and running tasks on the pool -->

--- a/src/app/components/pool/graphs/pool-graphs.html
+++ b/src/app/components/pool/graphs/pool-graphs.html
@@ -6,7 +6,7 @@
     </bl-banner>
     <bl-banner *ngIf="unusableNodeError">
         <div message>{{unusableNodeError.failedUnusableNodes}} out of {{unusableNodeError.nodeCount}} nodes are in an unusable state.
-            Please click nodes for more details.
+            Please click the nodes for more details.
         </div>
     </bl-banner>
 </div>

--- a/src/app/components/pool/graphs/pool-graphs.html
+++ b/src/app/components/pool/graphs/pool-graphs.html
@@ -1,5 +1,5 @@
 <bl-banner *ngIf="startTaskFailedError" fixMessage="Edit the start task" [fix]="openEditStartTask">
-    <div message>It seems like the start task is failing on {{startTaskFailedError.failedStartTaskNodes}} out of {{startTaskFailedError.nodeCount}} nodes.</div>
+    <div message>The start task has failed on {{startTaskFailedError.failedStartTaskNodes}} out of {{startTaskFailedError.nodeCount}} nodes.</div>
     <div [other-fix]="rebootFailedNodes" fixMessage="Reboot failed nodes"></div>
     <div *ngIf="isPaasPool" [other-fix]="reimageFailedNodes" fixMessage="Reimage failed nodes"></div>
 </bl-banner>

--- a/src/app/components/pool/graphs/pool-graphs.html
+++ b/src/app/components/pool/graphs/pool-graphs.html
@@ -4,7 +4,7 @@
     <div *ngIf="isPaasPool" [other-fix]="reimageFailedNodes" fixMessage="Reimage failed nodes"></div>
 </bl-banner>
 <bl-banner *ngIf="unusableNodeError">
-    <div message>It seems like {{unusableNodeError.failedUnusableNodes}} out of {{unusableNodeError.nodeCount}} nodes are unusable.</div>
+    <div message>{{unusableNodeError.failedUnusableNodes}} out of {{unusableNodeError.nodeCount}} nodes are in an unusable state.</div>
 </bl-banner>
 <bl-metrics-monitor class="graphs-container">
     <!-- Only show the heatmap, available nodes and running tasks on the pool -->


### PR DESCRIPTION
Added an error banner for unusable nodes:
* Changed tooltip for error nodes to display error instead of number of tasks running
* Added error banner for unusable nodes
* Changed error message for both unusable nodes and start task failed errors to be more explicit