### PR TITLE
Minor update to keytar to fix builds against node 12+.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9544,12 +9544,19 @@
       "dev": true
     },
     "keytar": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/keytar/-/keytar-4.4.1.tgz",
-      "integrity": "sha512-6xEe7ybXSR5EZC+z0GI2yqLYZjV1tyPQY2xSZ8rGsBxrrLEh8VR/Lfqv59uGX+I+W+OZxH0jCXN1dU1++ify4g==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-4.13.0.tgz",
+      "integrity": "sha512-qdyZ3XDuv11ANDXJ+shsmc+j/h5BHPDSn33MwkUMDg2EA++xEBleNkghr3Jg95cqVx5WgDYD8V/m3Q0y7kwQ2w==",
       "requires": {
-        "nan": "2.12.1",
-        "prebuild-install": "5.2.4"
+        "nan": "2.14.0",
+        "prebuild-install": "5.3.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+          "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+        }
       }
     },
     "keyv": {
@@ -10444,7 +10451,8 @@
     "nan": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -10465,9 +10473,9 @@
       }
     },
     "napi-build-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
-      "integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
     "negotiator": {
       "version": "0.6.1",
@@ -12162,9 +12170,9 @@
       "dev": true
     },
     "prebuild-install": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.4.tgz",
-      "integrity": "sha512-CG3JnpTZXdmr92GW4zbcba4jkDha6uHraJ7hW4Fn8j0mExxwOKK20hqho8ZuBDCKYCHYIkFM1P2jhtG+KpP4fg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.0.tgz",
+      "integrity": "sha512-aaLVANlj4HgZweKttFNUVNRxDukytuIuxeK2boIMHjagNJCiVKWFsKF4tCE3ql3GbrD2tExPQ7/pwtEJcHNZeg==",
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "inflection": "^1.12.0",
     "js-yaml": "^3.13.1",
     "jschardet": "^2.1.0",
-    "keytar": "^4.4.1",
+    "keytar": "^4.5.0",
     "load-json-file": "^5.2.0",
     "luxon": "^1.11.4",
     "make-dir": "^2.1.0",


### PR DESCRIPTION
Node 12+ has a breaking change with keytar 4.4.1. [4.5.0 fixes this issue.](https://github.com/atom/node-keytar/issues/174#issuecomment-486189608).