### PR TITLE
Fixed Windows/Linux packaging issues

### DIFF
--- a/scripts/package/package-utils.ts
+++ b/scripts/package/package-utils.ts
@@ -21,7 +21,7 @@ export const version = computeVersion();
 export const artifactsNames = {
     windowsInstaller: `BatchExplorer Setup ${version}.exe`,
     windowsZip: `BatchExplorer-${version}-win.zip`,
-    linuxAppImage: `BatchExplorer ${version}.AppImage`,
+    linuxAppImage: `BatchExplorer-${version}.AppImage`,
     darwinZip: `BatchExplorer-${version}-mac.zip`,
     darwinDmg: `BatchExplorer-${version}.dmg`,
     linuxRpm: `batch-explorer-${version}.x86_64.rpm`,

--- a/scripts/package/package.ts
+++ b/scripts/package/package.ts
@@ -20,19 +20,17 @@ async function baseBuild(options?: electronBuilder.CliOptions) {
 }
 
 /**
- * Just create the windows executable.
- * This is so exe can be signed before creating installer
+ * Create a standalone Windows executable
  */
 async function createWindowsExecutable() {
     return baseBuild({
         dir: true,
-        win: ["exe"],
+        win: ["portable"],
     });
 }
 
 /**
- * Just create the windows executable.
- * This is so exe can be signed before creating installer
+ * Create a Windows installer
  */
 async function createWindowsInstaller() {
     return baseBuild({
@@ -43,8 +41,7 @@ async function createWindowsInstaller() {
 }
 
 /**
- * Just create the mac os app file.
- * This is so app can be signed before creating the dmg
+ * Create an expanded MacOS application
  */
 async function createDarwinApp() {
     return baseBuild({
@@ -53,8 +50,7 @@ async function createDarwinApp() {
 }
 
 /**
- * Just create the mac os app file.
- * This is so app can be signed before creating the dmg
+ * Create a MacOS installer
  */
 async function createDarwinDmg() {
     return baseBuild({


### PR DESCRIPTION
Handles 2 breaking changes from the recent electron-builder update:

- The API for creating a standalone executable in electron-builder changed.
- The Linux AppImage binary filename changed.