### PR TITLE
Fixed Splash Screen Stuck Issue - Mac

### DIFF
--- a/src/client/splash-screen/splash-screen.ts
+++ b/src/client/splash-screen/splash-screen.ts
@@ -1,6 +1,6 @@
 import { BrowserWindow, nativeImage } from "electron";
 import { Constants } from "../client-constants";
-import { UniqueWindow } from "../core";
+import { UniqueWindow } from "../core/unique-window";
 
 const urls = Constants.urls.splash;
 const url = process.env.HOT ? urls.dev : urls.prod;

--- a/test/spectron/test-app-start.spec.ts
+++ b/test/spectron/test-app-start.spec.ts
@@ -95,7 +95,7 @@ async function signIn(client: SpectronClient) {
     const url = await client.getUrl();
     if (url.startsWith("https://msft.sts.microsoft.com")) {
         // Click on "Sign with email or passwork instead"
-        const signInWithEmailOrPasswordLink = await client.$(`#loginMessage .actionLink`);
+        const signInWithEmailOrPasswordLink = await client.$("#authOptions .optionButton");
         await signInWithEmailOrPasswordLink.click();
     }
 


### PR DESCRIPTION
When running in dev mode, Batch Explorer kept getting stuck on the splash screen for Mac. This minor change fixes this issue.