### PR TITLE
Replace hyphens in the build number with underscores

### DIFF
--- a/.vsts/dependencies.yml
+++ b/.vsts/dependencies.yml
@@ -1,5 +1,5 @@
 steps:
-  - powershell: ./scripts/azpipelines/build-type.ps1 "$(Build.SourceBranch)"
+  - powershell: ./scripts/azpipelines/build-type.ps1 "$(Build.SourceBranch)" "$(Build.BuildNumber)"
     displayName: Resolve build type
 
   - task: NodeTool@0

--- a/scripts/azpipelines/build-type.ps1
+++ b/scripts/azpipelines/build-type.ps1
@@ -1,5 +1,6 @@
 param (
-    $branch
+    $branch,
+    $buildNumber
 )
 # This compute the build type for VSTS build
 $buildType="dev"
@@ -22,3 +23,9 @@ If ($branch -like "refs/heads/feature/signing-vsts") {
 Write-Host "Build type is $buildType"
 Write-Host "##vso[build.addbuildtag]$buildType"
 Write-Host "##vso[task.setvariable variable=BUILD_TYPE]$buildType"
+
+# Hyphens in the version causes RPM packaging to fail
+# See https://azurebatch.visualstudio.com/BatchExplorer/_workitems/edit/379
+$newBuildNumber=$buildNumber -replace '-', '_'
+Write-Host "Setting build number to $newBuildNumber"
+Write-Host "##vso[build.updatebuildnumber]$newBuildNumber"

--- a/scripts/azpipelines/update-build-name.ps1
+++ b/scripts/azpipelines/update-build-name.ps1
@@ -1,4 +1,4 @@
 $version = npm run -s ts "scripts/package/get-version.ts"
 
-Write-Host "Version is $version"
+Write-Host "Updating build number to $version"
 Write-Host "##vso[build.updatebuildnumber]$version"


### PR DESCRIPTION
When manually building a PR branch, underscores would cause the RPM
build to fail