### PR TITLE
Fix freezing issue for 'pause on exceptions' in splash screen

### DIFF
--- a/src/client/main-window/main-window.ts
+++ b/src/client/main-window/main-window.ts
@@ -98,7 +98,7 @@ export class MainWindow extends GenericWindow {
 
         // Open the DevTools.
         if (process.env.NODE_ENV !== "production") {
-            window.webContents.openDevTools();
+            window.webContents.openDevTools({ mode: 'undocked' });
         }
 
         return window;


### PR DESCRIPTION
Add undocked mode for devtools when running Batch Explorer in development mode. When selecting 'pause on exceptions' in devtools, Batch Explorer would freeze at splash screen but devtools wasn't visible.