### PR TITLE
Fixes username in profile button

### DIFF
--- a/src/@batch-flask/core/data-store/user-specific-data-store/user-specific-data-store.spec.ts
+++ b/src/@batch-flask/core/data-store/user-specific-data-store/user-specific-data-store.spec.ts
@@ -29,12 +29,12 @@ describe("UserSpecificDataStore", () => {
 
         expect(spy).not.toHaveBeenCalled();
 
-        userServiceSpy.currentUser.next({ unique_name: "foo@example.com" });
+        userServiceSpy.currentUser.next({ username: "foo@example.com" });
     });
 
     describe("when the user is loaded", () => {
         beforeEach(() => {
-            userServiceSpy.currentUser.next({ unique_name: "foo@example.com" });
+            userServiceSpy.currentUser.next({ username: "foo@example.com" });
         });
 
         it("defaults to null when there is no value", async () => {
@@ -85,7 +85,7 @@ describe("UserSpecificDataStore", () => {
             });
 
             it("it gets value for the new user when switching", async () => {
-                userServiceSpy.currentUser.next({ unique_name: "other@example.com" });
+                userServiceSpy.currentUser.next({ username: "other@example.com" });
 
                 expect(await store.getItem("key-1")).toEqual("my-value-2");
                 expect(await store.getItem("key-2")).toEqual(null);

--- a/src/@batch-flask/core/data-store/user-specific-data-store/user-specific-data-store.ts
+++ b/src/@batch-flask/core/data-store/user-specific-data-store/user-specific-data-store.ts
@@ -8,7 +8,7 @@ import { GlobalStorage } from "../global-storage";
 export const USER_SERVICE = "USER_SERVICE";
 
 export interface User {
-    unique_name: string;
+    username: string;
 }
 
 export interface UserService {
@@ -34,7 +34,7 @@ export class UserSpecificDataStore implements DataStore, OnDestroy {
         this._currentUser = this.userService.currentUser.pipe(
             takeUntil(this._destroy),
             filter(isNotNullOrUndefined),
-            map(x => x.unique_name),
+            map(x => x.username),
             publishReplay(1),
             refCount(),
         );

--- a/src/app/components/layout/main-navigation/profile-button/profile-button.component.spec.ts
+++ b/src/app/components/layout/main-navigation/profile-button/profile-button.component.spec.ts
@@ -79,7 +79,7 @@ describe("ProfileButtonComponent", () => {
     it("shows the current user info in tooltip", () => {
         authServiceSpy.currentUser.next({
             name: "Some Name",
-            unique_name: "some.name@example.com",
+            username: "some.name@example.com",
         });
         fixture.detectChanges();
         const tooltip: MatTooltip = clickableEl.injector.get(MatTooltip);

--- a/src/app/components/layout/main-navigation/profile-button/profile-button.component.ts
+++ b/src/app/components/layout/main-navigation/profile-button/profile-button.component.ts
@@ -53,9 +53,9 @@ export class ProfileButtonComponent implements OnDestroy, OnInit {
         private fs: FileSystemService,
         private router: Router) {
 
-        authService.currentUser.pipe(takeUntil(this._destroy)).subscribe((user) => {
+        authService.currentUser.pipe(takeUntil(this._destroy)).subscribe(user => {
             if (user) {
-                this.currentUserName = `${user.name} (${user.unique_name})`;
+                this.currentUserName = `${user.name} (${user.username})`;
             } else {
                 this.currentUserName = "";
             }

--- a/src/client/core/aad/auth/aad-user.ts
+++ b/src/client/core/aad/auth/aad-user.ts
@@ -45,15 +45,6 @@ export interface AADUser {
      */
     amr?: string[];
 
-    /**
-     * Last name of user
-     */
-    family_name?: string;
-
-    /**
-     * First name of user
-     */
-    given_name: string;
     ipaddr: string;
 
     /**
@@ -73,22 +64,19 @@ export interface AADUser {
     tid?: string;
 
     /**
-     * Unique name
      * Provides a human readable value that identifies the subject of the token.
-     * This value is not guaranteed to be unique within a tenant and is designed to be used only for display purposes.
-     */
-    unique_name: string;
-
-    /**
-     * User principal name
-     * Stores the user name of the user principal.
      * @example "frankm@contoso.com"
      */
-    upn?: string;
+    preferred_username: string;
 
     /**
      * Version
      * @example 1.0
      */
     ver?: string;
+
+    /**
+     * The calculated username
+     */
+    username?: string;
 }

--- a/src/client/core/aad/auth/aad.service.spec.ts
+++ b/src/client/core/aad/auth/aad.service.spec.ts
@@ -16,8 +16,6 @@ const sampleUser: AADUser = {
     nbf: 1483372574,
     exp: 1483376474,
     amr: ["pwd", "mfa"],
-    family_name: "Smith",
-    given_name: "Frank",
     ipaddr: "198.217.117.26",
     name: "Frank Smith",
     nonce: "be4e7843-305e-42ab-988d-7ee109989d70",
@@ -25,8 +23,8 @@ const sampleUser: AADUser = {
     platf: "5",
     sub: "0WzjD2jhHJVb-3h2PbwUDCJOIPPIJmQQYE832uFqiII",
     tid: "72f988bf-86f1-41af-91ab-2d7cd011db47",
-    unique_name: "frank.smith@example.com",
-    upn: "frank.smith@example.com",
+    preferred_username: "frank.smith@example.com",
+    username: "frank.smith@example.com",
     ver: "1.0",
 };
 
@@ -93,7 +91,7 @@ describe("AADService", () => {
         let user: AADUser | null = null;
         tmpService.currentUser.subscribe(x => user = x);
         expect(user).not.toBeNull();
-        expect(user.upn).toEqual("frank.smith@example.com");
+        expect(user.username).toEqual("frank.smith@example.com");
         done();
     });
 

--- a/src/client/core/aad/auth/aad.service.ts
+++ b/src/client/core/aad/auth/aad.service.ts
@@ -199,7 +199,7 @@ export class AADService {
     private _processUserToken(idToken: string) {
         const user = this._userDecoder.decode(idToken);
         const prevUser = this._currentUser.value;
-        if (!prevUser || prevUser.unique_name !== user.unique_name) {
+        if (!prevUser || prevUser.username !== user.username) {
             this._clearUserSpecificCache();
         }
         this._currentUser.next(user);

--- a/src/client/core/aad/auth/user-decoder.ts
+++ b/src/client/core/aad/auth/user-decoder.ts
@@ -16,7 +16,7 @@ export class UserDecoder {
         const decodedPayLoad = this.safeDecodeBase64(jwtDecoded.JWSPayload);
 
         const user = JSON.parse(decodedPayLoad);
-
+        user.username = user.preferred_username;
         return user as AADUser;
     }
 


### PR DESCRIPTION
MSAL access tokens have a different interface, using `preferred_username` instead of `unique_name`. The AADUser object now has a new `username` attribute that abstracts away how the access token stores the username.

Also removed the following non-existent (and unused) attributes: `upn`, `given_name`, `last_name`.

Fixes #2334