### PR TITLE
Fix sort icon luminosity contrast ratio too low

### DIFF
--- a/src/@batch-flask/ui/table/table.scss
+++ b/src/@batch-flask/ui/table/table.scss
@@ -174,7 +174,6 @@ bl-table {
 
             .sort-icon {
                 margin-left: 3px;
-                color: $main-background;
             }
 
             &:hover:not(.sorting) > .sort-icon {


### PR DESCRIPTION
The sort icon color contrast (5.7:1) is the same as the label as shown in the screenshot below. When clicked, it turns blue.
![image](https://user-images.githubusercontent.com/16728220/124337465-9dbd5200-db57-11eb-86b9-fa9c5a022e4a.png)
