### PR TITLE
Fix favorite item pinned visual focus indicator through keyboard

### DIFF
--- a/src/app/components/layout/pinned-entity-dropdown/pinned-dropdown.component.spec.ts
+++ b/src/app/components/layout/pinned-entity-dropdown/pinned-dropdown.component.spec.ts
@@ -125,7 +125,7 @@ describe("PinnedDropDownComponent", () => {
         });
 
         it("drop down should have 1 item", () => {
-            const items = fixture.debugElement.queryAll(By.css(".dropdown-item"));
+            const items = fixture.debugElement.queryAll(By.css(".favorite-item"));
             expect(items.length).toBe(1);
             expect(items[0].nativeElement.textContent).toContain("my-job-fred");
 
@@ -164,12 +164,12 @@ describe("PinnedDropDownComponent", () => {
         });
 
         it("drop down should have 2 items", () => {
-            const items = debugElement.queryAll(By.css(".dropdown-item"));
+            const items = debugElement.queryAll(By.css(".favorite-item"));
             expect(items.length).toBe(2);
         });
 
         it("pool should show name over id", () => {
-            const items = debugElement.queryAll(By.css(".dropdown-item"));
+            const items = debugElement.queryAll(By.css(".favorite-item"));
             expect(items[0].nativeElement.textContent).toContain("my-job-matt");
             expect(items[1].nativeElement.textContent).toContain("my-name-is-bob");
             expect(items[1].nativeElement.textContent).not.toContain("my-pool-bob");

--- a/src/app/components/layout/pinned-entity-dropdown/pinned-dropdown.html
+++ b/src/app/components/layout/pinned-entity-dropdown/pinned-dropdown.html
@@ -4,19 +4,21 @@
     </div>
     <div bl-dropdown-content>
         <div *ngFor="let favorite of favorites | async;trackBy: trackPinnned"
-            class="dropdown-item favorite"
+            class="dropdown-favorite-container"
             [class.selected]="favorite.url === currentUrl"
             (click)="gotoFavorite(favorite)"
             (mouseup)="handleMiddleMouseUp($event, favorite)"
             (contextmenu)="onContextMenu(favorite)">
 
-            <span>
-                <i class="entity-type fa" [ngClass]="entityIcon(favorite)"
-                [title]="entityType(favorite)"></i>
-                {{favorite.name || favorite.id}}
-                <i *ngIf="favorite.url === currentUrl" class="extra fa fa-check"></i>
-            </span>
-            <bl-clickable class="delete" (do)="removeFavorite(favorite)">
+            <bl-clickable class="dropdown-item favorite-item" (do)="gotoFavorite(favorite)">
+                <span>
+                    <i class="entity-type fa" [ngClass]="entityIcon(favorite)"
+                    [title]="entityType(favorite)"></i>
+                    {{favorite.name || favorite.id}}
+                    <i *ngIf="favorite.url === currentUrl" class="extra fa fa-check"></i>
+                </span>
+            </bl-clickable>
+            <bl-clickable class="dropdown-item delete" (do)="removeFavorite(favorite)">
                 <i class="fa fa-times" ></i>
             </bl-clickable>
         </div>

--- a/src/app/components/layout/pinned-entity-dropdown/pinned-dropdown.scss
+++ b/src/app/components/layout/pinned-entity-dropdown/pinned-dropdown.scss
@@ -7,14 +7,18 @@ bl-pinned-dropdown {
         max-width: 350px;
     }
 
-    .dropdown-item.favorite {
-        position: relative;
-        min-width: 250px;
-        cursor: pointer;
-        padding: 0;
+    .dropdown-favorite-container {
         display: flex;
         align-items: stretch;
         justify-content: stretch;
+        padding: 0;
+    }
+
+    .dropdown-favorite-container > .favorite-item {
+        flex-grow: 2;
+        min-width: 250px;
+        cursor: pointer;
+        padding: 0;
 
         &:hover {
             i.fa {
@@ -37,7 +41,6 @@ bl-pinned-dropdown {
             min-width: 20px;
             text-overflow: ellipsis;
             overflow-x: hidden;
-            border-right: 1px solid $border-color;
             padding: 5px 10px;
 
             &:hover {
@@ -54,24 +57,25 @@ bl-pinned-dropdown {
                 }
             }
         }
+    }
 
-        > .delete {
-            flex: 0 0 30px;
-            background-color: $card-background;
-            color: $primary-color-dark;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            cursor: pointer;
+    .dropdown-favorite-container > .delete {
+        flex: 0 0 30px;
+        background-color: $card-background;
+        color: $primary-color-dark;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        border-left: 1px solid $border-color;
+        min-width: unset;
 
-            &:hover {
-                color: $card-background;
-                background-color: $danger-color;
-            }
+        &:hover {
+            background-color: $danger-color;
+        }
 
-            &:active {
-                background-color:  $danger-color;
-            }
+        &:active {
+            background-color:  $danger-color;
         }
     }
 }


### PR DESCRIPTION
Fix bug [AB#574](https://azurebatch.visualstudio.com/3426cbfe-4c9a-4da4-88df-70f025a77017/_workitems/edit/574)

Previously, individual items could not be accessed through keyboard tabbing, only the Delete button for those items could. 
![image](https://user-images.githubusercontent.com/16728220/138787367-1a7aae2c-9c29-443f-bafc-cdb4bde71e3d.png)

Individual items in the favorite item drop down can be accessed through keyboard tabbing now.
![image](https://user-images.githubusercontent.com/16728220/138787403-a214898c-5fd3-4ddb-b3ed-51046f300017.png)



