### PR TITLE
Fix code-signing on Mac

### DIFF
--- a/.vsts/darwin/sign.yml
+++ b/.vsts/darwin/sign.yml
@@ -1,4 +1,10 @@
 steps:
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
+    inputs:
+      packageType: sdk
+      version: 2.1.x
+
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
     inputs:
       ConnectedServiceName: 'ESRP CodeSign'


### PR DESCRIPTION
Explicitly download .NET Core 2.1 for use by codesigning task on Mac agents. This is a mitigation step to make codesigning work until the task is upgraded.