### PR TITLE
vNext: Publish NPM packages to private artifact feed

### DIFF
--- a/.vsts/common/build-vars.ps1
+++ b/.vsts/common/build-vars.ps1
@@ -1,31 +1,44 @@
+# Sets build variables for use in various build stages
+
 param (
     $branch,
     $buildNumber
 )
 # This compute the build type for VSTS build
-$buildType="dev"
+$buildType = "dev"
+$distTag = "latest"
 
 Write-Host "Branch is $branch"
 
 If ($branch -like "refs/heads/master") {
-    $buildType="insider"
+    $buildType = "insider"
+    $distTag = "latest"
 }
 
 If ($branch -like "refs/heads/stable") {
-    $buildType="stable"
+    $buildType = "stable"
+    $distTag = "stable"
+}
+
+If ($branch -like "refs/heads/vnext") {
+    $buildType = "vnext"
+    $distTag = "next"
 }
 
 # Change to curent branch for testing
 If ($branch -like "refs/heads/feature/signing-vsts") {
-    $buildType="testing"
+    $buildType = "testing"
 }
 
 Write-Host "Build type is $buildType"
 Write-Host "##vso[build.addbuildtag]$buildType"
 Write-Host "##vso[task.setvariable variable=BUILD_TYPE]$buildType"
 
+Write-Host "Setting publication distribution tag to $distTag"
+Write-Host "##vso[task.setvariable variable=DIST_TAG]$distTag"
+
 # Hyphens in the version causes RPM packaging to fail
 # See https://azurebatch.visualstudio.com/BatchExplorer/_workitems/edit/379
-$newBuildNumber=$buildNumber -replace '-', '_'
+$newBuildNumber = $buildNumber -replace '-', '_'
 Write-Host "Setting build number to $newBuildNumber"
 Write-Host "##vso[build.updatebuildnumber]$newBuildNumber"

--- a/.vsts/dependencies.yml
+++ b/.vsts/dependencies.yml
@@ -1,5 +1,5 @@
 steps:
-  - powershell: ./.vsts/common/build-type.ps1 "$(Build.SourceBranch)" "$(Build.BuildNumber)"
+  - powershell: ./.vsts/common/build-vars.ps1 "$(Build.SourceBranch)" "$(Build.BuildNumber)"
     displayName: Resolve build type
 
   - template: ./node-setup.yml

--- a/.vsts/linux/distribution.yml
+++ b/.vsts/linux/distribution.yml
@@ -5,13 +5,36 @@ steps:
       . "$(Agent.WorkFolder)/.venv/batchexplorer/bin/activate"
       npm run build:package
     displayName: Build and pack
+
+  - template: ./publish-npm-package.yml
+    parameters:
+      packagePath: ./packages/common
+      packageName: "@batch/ui-common"
+
+  - template: ./publish-npm-package.yml
+    parameters:
+      packagePath: ./packages/react
+      packageName: "@batch/ui-react"
+
+  - template: ./publish-npm-package.yml
+    parameters:
+      packagePath: ./packages/service
+      packageName: "@batch/ui-service"
+
+  - template: ./publish-npm-package.yml
+    parameters:
+      packagePath: ./packages/playground
+      packageName: "@batch/ui-playground"
+
   - script: |
       set -e
       . "$(Agent.WorkFolder)/.venv/batchexplorer/bin/activate"
       npm run package linux-manifest
     workingDirectory: desktop
     displayName: Create manifest
+
   - template: ../common/generate-sbom.yml
+
   - template: ../common/publish-artifacts.yml
     parameters:
       folder: linux

--- a/.vsts/linux/linux-dependencies.yml
+++ b/.vsts/linux/linux-dependencies.yml
@@ -14,7 +14,7 @@ steps:
       echo "NPM version $(npm --version)"
       npm install -g codecov
       npm ci
-    displayName: Install Linux dependencies
+    displayName: Install NPM dependencies
   - script: |
       cd util/bux
       npm pack

--- a/.vsts/linux/publish-npm-package.yml
+++ b/.vsts/linux/publish-npm-package.yml
@@ -1,0 +1,14 @@
+parameters:
+  packagePath: ''
+  packageName: ''
+
+steps:
+  - bash: |
+      set -e
+      ver=$(npm pkg get version | sed 's/"//g')
+      package_version=$(echo "$ver-$DIST_TAG.$BUILD_BUILDNUMBER" | sed 's/_//g')
+      echo "Publishing package ${{parameters.packageName}}@$package_version"
+      npm version --no-git-tag-version $package_version
+      npm publish --tag $DIST_TAG
+    displayName: "Publish package: ${{parameters.packageName}}"
+    workingDirectory: ${{parameters.packagePath}}

--- a/.vsts/node-setup.yml
+++ b/.vsts/node-setup.yml
@@ -2,60 +2,16 @@ steps:
   - task: NodeTool@0
     inputs:
       versionSpec: '16.x.x'
+    displayName: Set NodeJS version
+
+  - script: cp .vsts/pipelines.npmrc $(Agent.TempDirectory)/.npmrc
+    displayName: Stage .npmrc file
+
+  - task: npmAuthenticate@0
+    displayName: NPM auth
+    inputs:
+      workingFile: $(Agent.TempDirectory)/.npmrc
 
   - script: |
-      cp .vsts/pipelines.npmrc .npmrc
-      cp .vsts/pipelines.npmrc desktop/.npmrc
-      cp .vsts/pipelines.npmrc packages/common/.npmrc
-      cp .vsts/pipelines.npmrc packages/playground/.npmrc
-      cp .vsts/pipelines.npmrc packages/react/.npmrc
-      cp .vsts/pipelines.npmrc packages/service/.npmrc
-      cp .vsts/pipelines.npmrc util/bux/.npmrc
-      cp .vsts/pipelines.npmrc util/common-config/.npmrc
-      cp .vsts/pipelines.npmrc web/.npmrc
-    displayName: Stage .npmrc configuration
-
-  - task: npmAuthenticate@0
-    displayName: NPM auth - root
-    inputs:
-      workingFile: .npmrc
-
-  - task: npmAuthenticate@0
-    displayName: NPM auth - desktop
-    inputs:
-      workingFile: desktop/.npmrc
-
-  - task: npmAuthenticate@0
-    displayName: NPM auth - common
-    inputs:
-      workingFile: packages/common/.npmrc
-
-  - task: npmAuthenticate@0
-    displayName: NPM auth - playground
-    inputs:
-      workingFile: packages/playground/.npmrc
-
-  - task: npmAuthenticate@0
-    displayName: NPM auth - react
-    inputs:
-      workingFile: packages/react/.npmrc
-
-  - task: npmAuthenticate@0
-    displayName: NPM auth - service
-    inputs:
-      workingFile: packages/service/.npmrc
-
-  - task: npmAuthenticate@0
-    displayName: NPM auth - bux
-    inputs:
-      workingFile: util/bux/.npmrc
-
-  - task: npmAuthenticate@0
-    displayName: NPM auth - common-config
-    inputs:
-      workingFile: util/common-config/.npmrc
-
-  - task: npmAuthenticate@0
-    displayName: NPM auth - web
-    inputs:
-      workingFile: web/.npmrc
+      echo "##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$(Agent.TempDirectory)/.npmrc"
+    displayName: Set NPM configuration environment variable

--- a/desktop/scripts/azpipelines/utils.ts
+++ b/desktop/scripts/azpipelines/utils.ts
@@ -22,6 +22,8 @@ export function getContainerName(buildType: string): string {
             return "stable";
         case "insider":
             return "insider";
+        case "vnext":
+            return "vnext";
         default:
             return "test";
     }

--- a/desktop/scripts/package/package-utils.ts
+++ b/desktop/scripts/package/package-utils.ts
@@ -15,6 +15,8 @@ export enum BuildType {
     Stable = "stable",
     // Build off master
     Insider = "insider",
+    // Temporary until shared-libraries are merged
+    Vnext = "vnext"
 }
 
 export const version = computeVersion();

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "independent",
   "npmClient": "npm",
   "useWorkspaces": false,
   "packages": ["desktop", "packages/*", "util/*", "web"]

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@batch/ui-common",
-  "private": true,
+  "private": false,
   "version": "1.0.0",
   "description": "Common library for Azure Batch user interfaces",
   "repository": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@batch/ui-playground",
-  "private": true,
+  "private": false,
   "version": "1.0.0",
   "description": "Playground for Azure Batch Shared Component Library",
   "repository": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@batch/ui-react",
-  "private": true,
+  "private": false,
   "version": "1.0.0",
   "description": "Azure Batch shared React component library",
   "repository": {

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@batch/ui-service",
-  "private": true,
+  "private": false,
   "version": "1.0.0",
   "description": "Library for communicating with the Azure Batch service",
   "repository": {


### PR DESCRIPTION
Publishes 4 packages to a private artifact feed whenever the distribution pipeline runs (a release or a PR merge):

* @batch/ui-common
* @batch/ui-react
* @batch/ui-service
* @batch/ui-playground

Depending on the release type, the published packages are assigned distribution tag (`npm-dist-tag`), which can then be used to fetch packages of a certain type:

| Branch | Build Type | Dist Tag |
|--------|------------|---------|
| master | insider        | latest     |
| stable  | stable          | stable    |
| vnext    | vnext          | next       |

Even though each package shares the same version (`1.0.0`), the pipeline gets the version from each package's `package.json` and appends a build ID, which is the distribution tag and the build number. So each published package will have a version of the form `1.0.0-latest.20221212.1`).

### Some other modifications to the Azure pipelines:

* Instead of running NPM auth on every package, it only runs the auth once (the task just populates an npmrc file with creds), and then sets an environment variable that's used by all future NPM commands, which means
* All the NPM publish stuff is in a small inline script instead of multiple steps per package.
* Renames `build-type.ps1` to `build-vars.ps1` to reflect that the script does more than just set the build type.