### PR TITLE
Bumps @azure/msal-node from 1.9.0 to 1.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@angular/platform-browser-dynamic": "^11.0.0",
         "@angular/platform-server": "^11.0.0",
         "@angular/router": "^11.0.0",
-        "@azure/msal-node": "^1.9.0",
+        "@azure/msal-node": "^1.10.0",
         "@azure/storage-blob": "^10.5.0",
         "applicationinsights": "^1.8.5",
         "azure-storage": "^2.10.7",
@@ -495,49 +495,24 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@azure/msal-common": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.3.0.tgz",
-      "integrity": "sha512-ZyLq9GdnLBi/83YpysE86TFKbA0TuvfNAN5Psqu20cdAjLo/4rw4ttiItdh1G//XeGErHk9qn57gi2AYU1b5/Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-7.0.0.tgz",
+      "integrity": "sha512-EkaHGjv0kw1RljhboeffM91b+v9d5VtmyG+0a/gvdqjbLu3kDzEfoaS5BNM9QqMzbxgZylsjAjQDtxdHLX/ziA==",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.9.0.tgz",
-      "integrity": "sha512-lw6ejz1WPqcdjkwp91Gidte98+kfGxHk9eYSmmpUChzrUUrZMFGvrtrvG3Qnr6bp5d4WijVge9LMe+2QQUMhoA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.10.0.tgz",
+      "integrity": "sha512-oSv9mg199FpRTe+fZ3o9NDYpKShOHqeceaNcCHJcKUaAaCojAbfbxD1Cvsti8BEsLKE6x0HcnjilnM1MKmZekA==",
       "dependencies": {
-        "@azure/msal-common": "^6.3.0",
-        "axios": "^0.21.4",
-        "https-proxy-agent": "^5.0.0",
+        "@azure/msal-common": "^7.0.0",
         "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "engines": {
         "node": "10 || 12 || 14 || 16 || 18"
-      }
-    },
-    "node_modules/@azure/msal-node/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@azure/msal-node/node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@azure/msal-node/node_modules/uuid": {
@@ -4023,14 +3998,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
-    },
-    "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
     },
     "node_modules/axobject-query": {
       "version": "2.2.0",
@@ -10484,6 +10451,7 @@
       "version": "1.14.8",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
       "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -24136,39 +24104,20 @@
       }
     },
     "@azure/msal-common": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.3.0.tgz",
-      "integrity": "sha512-ZyLq9GdnLBi/83YpysE86TFKbA0TuvfNAN5Psqu20cdAjLo/4rw4ttiItdh1G//XeGErHk9qn57gi2AYU1b5/Q=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-7.0.0.tgz",
+      "integrity": "sha512-EkaHGjv0kw1RljhboeffM91b+v9d5VtmyG+0a/gvdqjbLu3kDzEfoaS5BNM9QqMzbxgZylsjAjQDtxdHLX/ziA=="
     },
     "@azure/msal-node": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.9.0.tgz",
-      "integrity": "sha512-lw6ejz1WPqcdjkwp91Gidte98+kfGxHk9eYSmmpUChzrUUrZMFGvrtrvG3Qnr6bp5d4WijVge9LMe+2QQUMhoA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.10.0.tgz",
+      "integrity": "sha512-oSv9mg199FpRTe+fZ3o9NDYpKShOHqeceaNcCHJcKUaAaCojAbfbxD1Cvsti8BEsLKE6x0HcnjilnM1MKmZekA==",
       "requires": {
-        "@azure/msal-common": "^6.3.0",
-        "axios": "^0.21.4",
-        "https-proxy-agent": "^5.0.0",
+        "@azure/msal-common": "^7.0.0",
         "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-          "requires": {
-            "debug": "4"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-          "requires": {
-            "agent-base": "6",
-            "debug": "4"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -26972,14 +26921,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
-    },
-    "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "requires": {
-        "follow-redirects": "^1.14.0"
-      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -32254,7 +32195,8 @@
     "follow-redirects": {
       "version": "1.14.8",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
-      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
+      "dev": true
     },
     "font-awesome": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "@angular/platform-browser-dynamic": "^11.0.0",
     "@angular/platform-server": "^11.0.0",
     "@angular/router": "^11.0.0",
-    "@azure/msal-node": "^1.9.0",
+    "@azure/msal-node": "^1.10.0",
     "@azure/storage-blob": "^10.5.0",
     "applicationinsights": "^1.8.5",
     "azure-storage": "^2.10.7",


### PR DESCRIPTION
Addresses issue with caching multiple tokens for same user (AzureAD/microsoft-authentication-library-for-js#4486).