### PR TITLE
Fix login failures due to AADSTS50011 error

### DIFF
--- a/src/client/core/aad/aad-config.ts
+++ b/src/client/core/aad/aad-config.ts
@@ -2,5 +2,4 @@ export interface AADConfig {
     tenant: string;
     clientId: string;
     redirectUri: string;
-    logoutRedirectUri: string;
 }

--- a/src/client/core/aad/auth/aad.service.ts
+++ b/src/client/core/aad/auth/aad.service.ts
@@ -26,8 +26,7 @@ import { UserDecoder } from "./user-decoder";
 const aadConfig: AADConfig = {
     tenant: "common",
     clientId: "04b07795-8ddb-461a-bbee-02f9e1bf7b46", // Azure CLI
-    redirectUri: "urn:ietf:wg:oauth:2.0:oob",
-    logoutRedirectUri: "urn:ietf:wg:oauth:2.0:oob/logout",
+    redirectUri: "https://login.microsoftonline.com/common/oauth2/nativeclient",
 };
 
 @Injectable()

--- a/src/client/core/aad/authentication/authentication.service.spec.ts
+++ b/src/client/core/aad/authentication/authentication.service.spec.ts
@@ -12,7 +12,6 @@ const CONFIG = {
     tenant: "common",
     clientId: "abc",
     redirectUri: "http://localhost",
-    logoutRedirectUri: "http://localhost",
 };
 
 const FAKE_TOKEN = {

--- a/src/test/utils/mocks/auth/auth-provider.mock.ts
+++ b/src/test/utils/mocks/auth/auth-provider.mock.ts
@@ -72,7 +72,6 @@ export const createMockClientApplication = () => {
         tenant: null,
         clientId: null,
         redirectUri: null,
-        logoutRedirectUri: null
     });
     return new MockClientApplication(fakeAuthProvider);
 };


### PR DESCRIPTION
Fixes #2542

It looks like the AZ CLI changed their app configuration to disallow the redirect url "urn:ietf:wg:oauth:2.0:oob". Switched to using the recommended value of "https://login.microsoftonline.com/common/oauth2/nativeclient", however the proper fix is to stop using the AZ CLI's app ID and create our own for Batch Explorer.