### PR TITLE
Fix UsePythonVersion warning

### DIFF
--- a/.vsts/python-setup.yml
+++ b/.vsts/python-setup.yml
@@ -2,7 +2,7 @@ steps:
   - task: UsePythonVersion@0
     condition: eq( variables['Agent.OS'], 'Windows_NT' )
     inputs:
-      versionSpec: '3.9.x'
+      versionSpec: '3.9'
     displayName: Install Python 3.9 for Batch Explorer
 
   - bash: ./scripts/azpipelines/setup-python.sh


### PR DESCRIPTION
Using 3.9.x generated a spurious warning about not specifying an exact Python version