### PR TITLE
Temporarily disable permissions checking on buttons

### DIFF
--- a/src/@batch-flask/ui/buttons/clickable/clickable.component.ts
+++ b/src/@batch-flask/ui/buttons/clickable/clickable.component.ts
@@ -79,6 +79,7 @@ export class ClickableComponent implements OnChanges, OnDestroy {
             if (this.permissionService && this.permission) {
                 this._sub = this.permissionService.hasPermission(this.permission).subscribe((hasPermission) => {
                     // TODO: Reenable this line when permissions checking is able to handle custom roles
+                    //       Also uncomment the test in entity-command-button.component.spec.ts
                     // this._permissionDisabled = !hasPermission;
                     this._permissionDisabled = false;
                     if (hasPermission) {

--- a/src/@batch-flask/ui/buttons/clickable/clickable.component.ts
+++ b/src/@batch-flask/ui/buttons/clickable/clickable.component.ts
@@ -56,7 +56,7 @@ export class ClickableComponent implements OnChanges, OnDestroy {
     // Aria
     @Input() @HostBinding("attr.role") public role = "button";
     @HostBinding("attr.aria-disabled") public get ariaDisabled() { return this.disabled; }
- 
+
     public subtitle = "";
 
     private permissionService: PermissionService | null;
@@ -78,7 +78,9 @@ export class ClickableComponent implements OnChanges, OnDestroy {
             this._clearSubscription();
             if (this.permissionService && this.permission) {
                 this._sub = this.permissionService.hasPermission(this.permission).subscribe((hasPermission) => {
-                    this._permissionDisabled = !hasPermission;
+                    // TODO: Reenable this line when permissions checking is able to handle custom roles
+                    // this._permissionDisabled = !hasPermission;
+                    this._permissionDisabled = false;
                     if (hasPermission) {
                         this.subtitle = "";
                     } else {

--- a/src/@batch-flask/ui/entity-commands-list/button/entity-command-button.component.spec.ts
+++ b/src/@batch-flask/ui/entity-commands-list/button/entity-command-button.component.spec.ts
@@ -138,16 +138,18 @@ describe("EntityCommandButtonComponent", () => {
         expect(button.disabled).toBe(true);
     });
 
-    it("should disable button when not having permission", () => {
-        testComponent.command = newMockCommand({
-            permission: "admin",
-        });
-        fixture.detectChanges();
+    // TODO: Uncomment this test when permissions checking for buttons
+    //       is re-enabled
+    // it("should disable button when not having permission", () => {
+    //     testComponent.command = newMockCommand({
+    //         permission: "admin",
+    //     });
+    //     fixture.detectChanges();
 
-        const button = getButton();
-        expect(button).not.toBeFalsy();
-        expect(button.isDisabled).toBe(true);
-    });
+    //     const button = getButton();
+    //     expect(button).not.toBeFalsy();
+    //     expect(button.isDisabled).toBe(true);
+    // });
 
     it("click on button should trigger execute", () => {
         const command = testComponent.command = newMockCommand({});


### PR DESCRIPTION
Permissions checking is specifically looking for the "*" permission and doesn't handle custom roles which include specific actions like "Microsoft.Batch/batchAccounts/pools/write". Will re-enable this when the client-side permissions checking is made more robust.

Fixes #2077