### PR TITLE
Fixed Windows code signing

### DIFF
--- a/.vsts/win/sign.yml
+++ b/.vsts/win/sign.yml
@@ -5,6 +5,12 @@ parameters:
   pattern: ''
 
 steps:
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core sdk'
+    inputs:
+      packageType: sdk
+      version: 2.1.x
+
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
     displayName: ${{ parameters.name }}
     inputs:


### PR DESCRIPTION
.NET 2.x doesn't seem to be on our CI image anymore