### PR TITLE
Only set build variables when running dist pipelines

### DIFF
--- a/.vsts/common/set-dist-vars.yml
+++ b/.vsts/common/set-dist-vars.yml
@@ -1,0 +1,7 @@
+steps:
+
+  - powershell: $(Build.SourcesDirectory)/scripts/azpipelines/build-type.ps1 "$(Build.SourceBranch)" "$(Build.BuildNumber)"
+    displayName: Resolve build type
+
+  - powershell: $(Build.SourcesDirectory)/scripts/azpipelines/update-build-name.ps1
+    displayName: Resolve version

--- a/.vsts/darwin/distribution.yml
+++ b/.vsts/darwin/distribution.yml
@@ -1,4 +1,5 @@
 steps:
+  - template: ../common/set-dist-vars.yml
   - template: ./darwin-dependencies.yml
   - script: |
       set -e

--- a/.vsts/dependencies.yml
+++ b/.vsts/dependencies.yml
@@ -1,6 +1,3 @@
 steps:
-  - powershell: ./scripts/azpipelines/build-type.ps1 "$(Build.SourceBranch)" "$(Build.BuildNumber)"
-    displayName: Resolve build type
-
   - template: ./node-setup.yml
   - template: ./python-setup.yml

--- a/.vsts/linux/distribution.yml
+++ b/.vsts/linux/distribution.yml
@@ -1,4 +1,5 @@
 steps:
+  - template: ../common/set-dist-vars.yml
   - template: ./linux-dependencies.yml
   - script: |
       set -e

--- a/.vsts/win/distribution.yml
+++ b/.vsts/win/distribution.yml
@@ -1,8 +1,8 @@
 steps:
+  - template: ../common/set-dist-vars.yml
   - template: ./credscan.yml
   - template: ./win-dependencies.yml
-  - powershell: ./scripts/azpipelines/update-build-name.ps1
-    displayName: Resolve version
+
   - powershell: |
       . .vsts/win/exec.ps1
       $ErrorActionPreference = "Stop"


### PR DESCRIPTION
This will make it so PR validation runs don't need permissions to change build tags, etc.