### PR TITLE
Make form values read-only

### DIFF
--- a/packages/common/src/ui-common/action/__tests__/action.spec.ts
+++ b/packages/common/src/ui-common/action/__tests__/action.spec.ts
@@ -20,7 +20,7 @@ describe("Action tests", () => {
         // Action hasn't been executed, message is the default
         expect(action.message).toEqual("Hello world");
 
-        action.form.values = { subject: "universe" };
+        action.form.setValues({ subject: "universe" });
 
         await action.execute();
 
@@ -66,16 +66,16 @@ describe("Action tests", () => {
         );
 
         // Override parameter validation in form onValidate() to force success
-        action.form.values.skipSubjectValidation = true;
+        action.form.updateValue("skipSubjectValidation", true);
         await action.form.validate();
         expect(action.onValidateCallCount).toEqual(3);
         expect(action.subjectOnValidateCallCount).toEqual(0);
         expect(action.form.validationStatus?.level).toEqual("ok");
 
         // Parameter onValidate failure
-        action.form.values = {
+        action.form.setValues({
             subject: "world",
-        };
+        });
         await action.form.validate();
         expect(action.onValidateCallCount).toEqual(4);
         // Subject onValidate() was called now that the required check passed
@@ -92,9 +92,9 @@ describe("Action tests", () => {
         );
 
         // Normal success
-        action.form.values = {
+        action.form.setValues({
             subject: "universe",
-        };
+        });
         await action.form.validate();
         expect(action.onValidateCallCount).toEqual(5);
         expect(action.subjectOnValidateCallCount).toEqual(2);

--- a/packages/playground/src/ui-playground/demo/form/action-form-demo.tsx
+++ b/packages/playground/src/ui-playground/demo/form/action-form-demo.tsx
@@ -106,7 +106,7 @@ export const ActionFormDemo: React.FC = () => {
                         4
                     ) !== textContent
                 ) {
-                    actions[action].form.values = JSON.parse(textContent);
+                    actions[action].form.setValues(JSON.parse(textContent));
                 }
                 setEditorError("");
             } catch (e) {

--- a/packages/react/src/ui-react/account/__tests__/create-account-action.spec.tsx
+++ b/packages/react/src/ui-react/account/__tests__/create-account-action.spec.tsx
@@ -36,7 +36,7 @@ describe("Create account action", () => {
         );
 
         // Fix the account name issue and rerun validation
-        form.values.accountName = "myaccount";
+        form.updateValue("accountName", "myaccount");
 
         await action.form.validate();
 


### PR DESCRIPTION
Values should now be set through setValues() and updateValue() which will properly trigger change events