### PR TITLE
Added `initialized` property to environments

### DIFF
--- a/packages/common/src/ui-common/environment/__tests__/environment-util.spec.ts
+++ b/packages/common/src/ui-common/environment/__tests__/environment-util.spec.ts
@@ -49,10 +49,13 @@ describe("Environment tests", () => {
         );
     });
 
-    test("When a non-mock environment is loaded, no others may be initialized", () => {
-        initEnvironment(
-            new FakeBrowserEnvironment(cfg, mockDependencyFactories)
-        );
+    test("When a non-mock environment is loaded, no others may be initialized", async () => {
+        const env = new FakeBrowserEnvironment(cfg, mockDependencyFactories);
+        expect(env.initialized).toBe(false);
+        const initPromise = initEnvironment(env);
+        expect(env.initialized).toBe(true);
+
+        await initPromise;
 
         const browserEnv = getEnvironment() as FakeBrowserEnvironment;
         expect(browserEnv.config.browserName).toBe(
@@ -72,6 +75,7 @@ describe("Environment tests", () => {
     test("Can initialize mock environment many times", () => {
         initMockEnvironment();
         const envOne = getMockEnvironment();
+        expect(envOne.initialized).toBe(true);
         expect(envOne.uniqueId()).toEqual(0);
         expect(envOne.uniqueId()).toEqual(1);
 

--- a/packages/common/src/ui-common/environment/abstract-environment.ts
+++ b/packages/common/src/ui-common/environment/abstract-environment.ts
@@ -22,6 +22,12 @@ export abstract class AbstractEnvironment<
     abstract readonly name: EnvironmentName;
     readonly mode: EnvironmentMode;
 
+    private _initialized: boolean = false;
+
+    get initialized(): boolean {
+        return this._initialized;
+    }
+
     private _diContainer: DiContainer<D>;
 
     /**
@@ -101,6 +107,7 @@ export abstract class AbstractEnvironment<
     abstract beforeDestroy(): Promise<void>;
 
     async init(): Promise<void> {
+        this._initialized = true;
         this._assertNotDestroyed();
         this.beforeInit();
     }

--- a/packages/common/src/ui-common/environment/environment.ts
+++ b/packages/common/src/ui-common/environment/environment.ts
@@ -18,6 +18,14 @@ export interface Environment<C extends EnvironmentConfig> {
     config: C;
 
     /**
+     * True if this environment has been initialized, false otherwise.
+     *
+     * Note that `initialized = true` does not mean that initialization
+     * has finished, only that it has been started.
+     */
+    readonly initialized: boolean;
+
+    /**
      * Gets the logger for the current environment
      */
     getLogger(): Logger;


### PR DESCRIPTION
This is useful when used in the portal, to prevent blade env initialization from happening more than once.