### PR TITLE
Updates AB#535: Removes test code

### DIFF
--- a/src/app/components/account/base/auto-storage-account-picker/auto-storage-account-picker.component.ts
+++ b/src/app/components/account/base/auto-storage-account-picker/auto-storage-account-picker.component.ts
@@ -86,8 +86,7 @@ export class AutoStorageAccountPickerComponent implements OnInit, ControlValueAc
     private _processStorageAccounts(storageAccounts: List<StorageAccount>) {
         const prefered = [];
         const others = [];
-        storageAccounts.forEach((account, i) => {
-            account.isClassic = i % 2 === 0;
+        storageAccounts.forEach((account) => {
             if (account.location.toLowerCase() === this.account.location.toLowerCase()) {
                 prefered.push(account);
             } else {


### PR DESCRIPTION
Test code showed every other storage account in the list classic (in order to work on the tooltip).