### PR TITLE
Fix LocProject file so resjson files are generated

### DIFF
--- a/Localize/LocProject.json
+++ b/Localize/LocProject.json
@@ -5,22 +5,27 @@
       "LocItems": [
         {
           "SourceFile": "packages\\common\\i18n\\resources.resjson",
+          "CopyOption": "LangIDOnName",
           "OutputPath": "packages\\common\\i18n"
         },
         {
           "SourceFile": "packages\\playground\\i18n\\resources.resjson",
+          "CopyOption": "LangIDOnName",
           "OutputPath": "packages\\playground\\i18n"
         },
         {
           "SourceFile": "packages\\react\\i18n\\resources.resjson",
+          "CopyOption": "LangIDOnName",
           "OutputPath": "packages\\react\\i18n"
         },
         {
           "SourceFile": "packages\\service\\i18n\\resources.resjson",
+          "CopyOption": "LangIDOnName",
           "OutputPath": "packages\\service\\i18n"
         },
         {
           "SourceFile": "desktop\\i18n\\resources.resjson",
+          "CopyOption": "LangIDOnName",
           "OutputPath": "desktop\\i18n"
         }
       ]


### PR DESCRIPTION
- I forgot to set the CopyOption in LocProject.json, which meant that the language resjson files were not being generated. 
- This PR fixes that issue so that the i18n folder in each package will have language files formatted as resources.{lang}.resjson: resources.fr.resjson, resources.es.resjson, resources.ko.resjson, etc.

From the [OneLocBuild](https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task?anchor=copyoption%2C-outputpath-(optional)]) docs:
CopyOption, OutputPath (Optional) 
- These two options facilitate the post-processing of resulting localized files when they are used together. When CopyOption is set to `LangIDOnName`, localized files are copied to OutputPath with a language ID in the filename such as {OutputPath}\A.ko.resx for ko (Korean). When CopyOption is set to `LangIDOnPath`, localized files are copied under OutputPath with a language ID folder such as {OutputPath}\ko\B.resjson for ko (Korean). Use the repo root as a base path for OutputPath. **When unspecified, no post-processing takes place.** 
- When CopyOption is set to LangIDOnPath, you can specify the Container of localized files under each language ID folder additionally if required. For example, Container should be set to Foo if B.resjson likes to be copied as {OutputPath}\ko\Foo\B.resjson for ko (Korean).