### PR TITLE
Fixes #2662: Restores Python backend

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,9 @@
 websockets==10.1
 pylint==2.3.0
 azure-batch-extensions==9.0.0
+
+# Explicitly needed for azure-batch-extensions:
+azure-multiapi-storage==1.0.0
+
 pyinstaller==4.9
 azure-batch==12.0.0


### PR DESCRIPTION
Updated Batch CLI extensions (v9.0.0) require `azure-multiapi-storage` as explicit requirement.