### PR TITLE
Keyboard accessibility bugs (463, 853)

### DIFF
--- a/src/@batch-flask/ui/form/complex-form/complex-form.component.ts
+++ b/src/@batch-flask/ui/form/complex-form/complex-form.component.ts
@@ -1,5 +1,5 @@
 import {
-    AfterViewInit, ChangeDetectorRef, Component, ContentChildren, HostBinding, Input, OnChanges, QueryList, Type,
+    AfterViewInit, ChangeDetectorRef, Component, ContentChildren, ElementRef, HostBinding, Input, OnChanges, QueryList, Type, ViewChild,
 } from "@angular/core";
 import { FormControl } from "@angular/forms";
 import { AsyncTask, Dto, ServerError, autobind } from "@batch-flask/core";
@@ -70,6 +70,8 @@ export class ComplexFormComponent extends FormBase implements AfterViewInit, OnC
     @Input() @HostBinding("class.sticky-footer") public stickyFooter: boolean = true;
 
     @ContentChildren(FormPageComponent) public pages: QueryList<FormPageComponent>;
+
+    @ViewChild('formElement') formElement: ElementRef;
 
     public mainPage: FormPageComponent;
     public currentPage: FormPageComponent;
@@ -168,6 +170,10 @@ export class ComplexFormComponent extends FormBase implements AfterViewInit, OnC
         }
         this._pageStack.push(this.currentPage);
         this.currentPage = page;
+
+        setTimeout(() => {
+            this.focusFirstFocusableElement()
+        });
     }
 
     @autobind()
@@ -267,5 +273,9 @@ export class ComplexFormComponent extends FormBase implements AfterViewInit, OnC
             cancel: this.cancelText,
             multiUse: this.multiUse,
         };
+    }
+
+    private focusFirstFocusableElement() {
+        this.formElement.nativeElement?.querySelector('[autofocus], button, input, textarea, select')?.focus()
     }
 }

--- a/src/@batch-flask/ui/form/complex-form/complex-form.html
+++ b/src/@batch-flask/ui/form/complex-form/complex-form.html
@@ -10,7 +10,7 @@
             </div>
         </div>
         <div *ngIf="!showJsonEditor" class="classic-form-container">
-            <form novalidate>
+            <form #formElement novalidate>
                 <ng-template [ngTemplateOutlet]="currentPage.content"></ng-template>
             </form>
         </div>

--- a/src/app/components/account/base/auto-storage-account-picker/auto-storage-account-picker.component.ts
+++ b/src/app/components/account/base/auto-storage-account-picker/auto-storage-account-picker.component.ts
@@ -112,13 +112,13 @@ export class AutoStorageAccountPickerComponent implements OnInit, ControlValueAc
      * to define a custom handler.
      */
     onKeydown(event: KeyboardEvent) {
-        this.classicTooltip.hide();
+        this.classicTooltip?.hide();
         if (event.key === "ArrowDown" || event.key === "ArrowUp" ||
             event.key === "Tab") {
             if (this.selectedStorageAccounts.size === 1) {
                 const id = this.selectedStorageAccounts.values().next().value;
                 if (this.classicAccounts.has(id)) {
-                    this.classicTooltip.show();
+                    this.classicTooltip?.show();
                 }
             }
         }

--- a/src/app/components/account/base/auto-storage-account-picker/auto-storage-account-picker.html
+++ b/src/app/components/account/base/auto-storage-account-picker/auto-storage-account-picker.html
@@ -1,6 +1,6 @@
 <bl-loading [status]="loadingStatus">
     <div *ngIf="loadingStatus">
-        <bl-button type="wide" (do)="pickStorageAccount(noSelectionKey)">
+        <bl-button type="wide" (do)="pickStorageAccount(noSelectionKey)" autofocus>
             {{'auto-storage-account-picker.clear-button-label' | i18n}}
         </bl-button>
         <h3>{{'auto-storage-account-picker.same-region-title' | i18n: {

--- a/src/app/components/job/action/add/job-preparation-task-picker.html
+++ b/src/app/components/job/action/add/job-preparation-task-picker.html
@@ -1,7 +1,7 @@
 <div [formGroup]="form">
     <div class="form-element">
         <bl-form-field>
-            <input blInput formControlName="id" placeholder="ID">
+            <input blInput autofocus formControlName="id" placeholder="ID">
         </bl-form-field>
         <bl-error controlName="id" code="required">ID is a required field</bl-error>
     </div>

--- a/src/app/components/job/action/add/job-release-task-picker.html
+++ b/src/app/components/job/action/add/job-release-task-picker.html
@@ -1,7 +1,7 @@
 <div [formGroup]="form">
     <div class="form-element">
         <bl-form-field>
-            <input blInput formControlName="id" placeholder="ID">
+            <input blInput autofocus formControlName="id" placeholder="ID">
         </bl-form-field>
         <bl-error controlName="id" code="required">ID is a required field</bl-error>
     </div>


### PR DESCRIPTION
### Resolves:
 
- [Bug 853]: [Keyboard Navigation-Batch Explorer-SetUp]: Keyboard focus does not land on the first interactive control as soon as we invoke the 'Setup' control in Storage accounts pane.
- [Bug 463]: [Keyboard Navigation -Batch Explorer - Job preparation task] After activating ‘Job preparation task’ keyboard focus does not lands on first interactive control.

### Notable changes:

- Updated the `bl-complex-form` implementation so that it automatically focuses the first element in any `nested-form`s when they open. As a result, this fixes all instances of `bl-complex-form` that had similar auto focus issues, not just the "Job preparation task" form in the bug above. For example, a similar issue was found in the "Job manager task" nested form, which should be fixed now as well.
- Fixed runtime error causing keyboard tab navigation to stop working in the Storage accounts pane mentioned above