### PR TITLE
Luminosity contrast accessibility bugs (568, 569)

### DIFF
--- a/data/themes/classic.json
+++ b/data/themes/classic.json
@@ -3,7 +3,7 @@
   "type": "standard",
   "primary": "#2F71C4",
   "primary-contrast": "#ffffff",
-  "danger": "#aa3939",
+  "danger": "#bc2f34",
   "danger-contrast": "#ffffff",
   "warn": "#a46026",
   "warn-contrast": "#ffffff",
@@ -53,16 +53,16 @@
     "disabled-bg": "#ededed"
   },
   "monitorChart": {
-    "core-count": "#1c3f95",
+    "core-count": "#004e8c",
     "low-priority-core-count": "#a36a00",
-    "task-start-event": "#a36a00",
-    "task-complete-event": "#428000",
-    "task-fail-event": "#aa3939",
-    "starting-node-count": "#1c3f95",
-    "idle-node-count": "#be93d9",
-    "running-node-count": "#428000",
-    "start-task-failed-node-count": "#aa3939",
-    "rebooting-node-count": "#ff755c"
+    "task-start-event": "#6d5700",
+    "task-complete-event": "#0f700f",
+    "task-fail-event": "#bc2f34",
+    "starting-node-count": "#004e8c",
+    "idle-node-count": "#8764b8",
+    "running-node-count": "#0f700f",
+    "start-task-failed-node-count": "#bc2f34",
+    "rebooting-node-count": "#d93c20"
   },
   "input": {
     "border": "#919191",
@@ -74,5 +74,5 @@
     "disabled-text": "var(--color-text-primary)",
     "disabled-background": "#e5e5e5"
   },
-  "chart-colors": ["#003f5c", "#aa3939", "#4caf50", "#ffa600"]
+  "chart-colors": ["#003f5c", "#bc2f34", "#4caf50", "#ffa600"]
 }

--- a/data/themes/dark.json
+++ b/data/themes/dark.json
@@ -14,6 +14,18 @@
     "primary": "#cccccc",
     "secondary": "#a7a8a9"
   },
+  "monitorChart": {
+    "core-count": "#0A95FF",
+    "low-priority-core-count": "#AE8C00",
+    "task-start-event": "#AE8C00",
+    "task-complete-event": "#0A95FF",
+    "task-fail-event": "#F26363",
+    "starting-node-count": "#0A95FF",
+    "idle-node-count": "#C674D2",
+    "running-node-count": "#44A744",
+    "start-task-failed-node-count": "#F26363",
+    "rebooting-node-count": "#DB7843"
+  },
   "breadcrumb": {
     "text": "white",
     "background": "#5b5b5b",

--- a/src/@batch-flask/ui/form/complex-form/complex-form.component.ts
+++ b/src/@batch-flask/ui/form/complex-form/complex-form.component.ts
@@ -1,5 +1,5 @@
 import {
-    AfterViewInit, ChangeDetectorRef, Component, ContentChildren, HostBinding, Input, OnChanges, QueryList, Type,
+    AfterViewInit, ChangeDetectorRef, Component, ContentChildren, ElementRef, HostBinding, Input, OnChanges, QueryList, Type, ViewChild,
 } from "@angular/core";
 import { FormControl } from "@angular/forms";
 import { AsyncTask, Dto, ServerError, autobind } from "@batch-flask/core";
@@ -70,6 +70,8 @@ export class ComplexFormComponent extends FormBase implements AfterViewInit, OnC
     @Input() @HostBinding("class.sticky-footer") public stickyFooter: boolean = true;
 
     @ContentChildren(FormPageComponent) public pages: QueryList<FormPageComponent>;
+
+    @ViewChild('formElement') formElement: ElementRef;
 
     public mainPage: FormPageComponent;
     public currentPage: FormPageComponent;
@@ -168,6 +170,10 @@ export class ComplexFormComponent extends FormBase implements AfterViewInit, OnC
         }
         this._pageStack.push(this.currentPage);
         this.currentPage = page;
+
+        setTimeout(() => {
+            this.focusFirstFocusableElement()
+        });
     }
 
     @autobind()
@@ -267,5 +273,9 @@ export class ComplexFormComponent extends FormBase implements AfterViewInit, OnC
             cancel: this.cancelText,
             multiUse: this.multiUse,
         };
+    }
+
+    private focusFirstFocusableElement() {
+        this.formElement.nativeElement?.querySelector('[autofocus], button, input, textarea, select')?.focus()
     }
 }

--- a/src/@batch-flask/ui/form/complex-form/complex-form.html
+++ b/src/@batch-flask/ui/form/complex-form/complex-form.html
@@ -10,7 +10,7 @@
             </div>
         </div>
         <div *ngIf="!showJsonEditor" class="classic-form-container">
-            <form novalidate>
+            <form #formElement novalidate>
                 <ng-template [ngTemplateOutlet]="currentPage.content"></ng-template>
             </form>
         </div>

--- a/src/@batch-flask/ui/form/form-field/form-field.scss
+++ b/src/@batch-flask/ui/form/form-field/form-field.scss
@@ -20,13 +20,21 @@ bl-form-field {
 
 
         > .input-prefix, > .input-suffix {
-            background: $input-border-color;
+            background: $secondary-background;
             border: 1px solid $input-border-color;
             height: 26px;
             padding: 0 5px;
             line-height: 26px;
             vertical-align: middle;
             color: $primary-text;
+        }
+
+        > .input-prefix {
+            border-right: none;
+        }
+
+        > .input-suffix {
+            border-left: none;
         }
     }
     .bl-form-field-label {}

--- a/src/app/components/account/base/auto-storage-account-picker/auto-storage-account-picker.component.ts
+++ b/src/app/components/account/base/auto-storage-account-picker/auto-storage-account-picker.component.ts
@@ -112,13 +112,13 @@ export class AutoStorageAccountPickerComponent implements OnInit, ControlValueAc
      * to define a custom handler.
      */
     onKeydown(event: KeyboardEvent) {
-        this.classicTooltip.hide();
+        this.classicTooltip?.hide();
         if (event.key === "ArrowDown" || event.key === "ArrowUp" ||
             event.key === "Tab") {
             if (this.selectedStorageAccounts.size === 1) {
                 const id = this.selectedStorageAccounts.values().next().value;
                 if (this.classicAccounts.has(id)) {
-                    this.classicTooltip.show();
+                    this.classicTooltip?.show();
                 }
             }
         }

--- a/src/app/components/account/base/auto-storage-account-picker/auto-storage-account-picker.html
+++ b/src/app/components/account/base/auto-storage-account-picker/auto-storage-account-picker.html
@@ -1,6 +1,6 @@
 <bl-loading [status]="loadingStatus">
     <div *ngIf="loadingStatus">
-        <bl-button type="wide" (do)="pickStorageAccount(noSelectionKey)">
+        <bl-button type="wide" (do)="pickStorageAccount(noSelectionKey)" autofocus>
             {{'auto-storage-account-picker.clear-button-label' | i18n}}
         </bl-button>
         <h3>{{'auto-storage-account-picker.same-region-title' | i18n: {

--- a/src/app/components/account/monitoring/monitor-chart/monitor-chart.component.ts
+++ b/src/app/components/account/monitoring/monitor-chart/monitor-chart.component.ts
@@ -196,7 +196,8 @@ export class MonitorChartComponent implements OnChanges, OnDestroy {
             },
             tooltips: {
                 enabled: true,
-                mode: "index",
+                mode: "single",
+                position: "nearest",
                 callbacks: {
                     title: (tooltipItems, data) => {
                         return this._computeTooltipTitle(tooltipItems[0], data);

--- a/src/app/components/job/action/add/job-preparation-task-picker.html
+++ b/src/app/components/job/action/add/job-preparation-task-picker.html
@@ -1,7 +1,7 @@
 <div [formGroup]="form">
     <div class="form-element">
         <bl-form-field>
-            <input blInput formControlName="id" placeholder="ID">
+            <input blInput autofocus formControlName="id" placeholder="ID">
         </bl-form-field>
         <bl-error controlName="id" code="required">ID is a required field</bl-error>
     </div>

--- a/src/app/components/job/action/add/job-release-task-picker.html
+++ b/src/app/components/job/action/add/job-release-task-picker.html
@@ -1,7 +1,7 @@
 <div [formGroup]="form">
     <div class="form-element">
         <bl-form-field>
-            <input blInput formControlName="id" placeholder="ID">
+            <input blInput autofocus formControlName="id" placeholder="ID">
         </bl-form-field>
         <bl-error controlName="id" code="required">ID is a required field</bl-error>
     </div>


### PR DESCRIPTION
### This PR resolves:

- [Bug 568] [Visual Requirement-Batch Explorer-Add a batch account] Luminosity contrast ratio of the text "eastus.batch.azure.com" is less than 4.5:1 i.e 2.5:1.
- [Bug 569] [Visual Requirement-Batch Explorer-Node states] Luminosity contrast ratio of the text "Idle" is less than 4.5:1 i.e 2.5:1.

Dashboard – classic theme:

![Screen Shot 2023-03-23 at 1 32 56 PM](https://user-images.githubusercontent.com/79171711/227361177-1460c62a-e4e5-4156-9329-3d659b642e71.png)

Dashboard – dark theme:

![Screen Shot 2023-03-23 at 1 32 17 PM](https://user-images.githubusercontent.com/79171711/227361214-44eb6954-f305-45fe-b1e6-5075ff7e4345.png)

Form fields with suffix – classic theme:

![Screen Shot 2023-03-23 at 1 51 15 PM](https://user-images.githubusercontent.com/79171711/227361273-43677fee-cec1-4183-9459-1e60079a428f.png)

Form fields with suffix – dark theme:

![Screen Shot 2023-03-23 at 2 07 06 PM](https://user-images.githubusercontent.com/79171711/227361666-fba6ede2-ab62-40c8-b012-0848cf9e9eff.png)

### Notable changes:

- Updated colors of monitor chart and other parts of the UI on the dashboard for both classic and dark themes to have luminosity contrast ratio >=4.5:1 — bug above was specific to classic theme
- Update styles of bl-form-field to have luminosity contrast ratio >=4.5:1. This change should affect all instances of `<bl-form-field>` that uses `blFormFieldSuffix` or `blFormFieldPrefix`
- Update tooltip configuration of the "Node states" chart to improve visibility. Please see my inline comment below for additional information.
