### PR TITLE
Add x-ms-command-name header support

### DIFF
--- a/packages/common/src/ui-common/http/__tests__/fetch-http-client.spec.ts
+++ b/packages/common/src/ui-common/http/__tests__/fetch-http-client.spec.ts
@@ -1,9 +1,17 @@
 import { FetchHttpClient } from "../fetch-http-client";
+import { HttpHeaders } from "../http-client";
+import { MapHttpHeaders } from "../map-http-headers";
 import { MockHttpResponse } from "../mock-http-client";
+
+const RealHeaders = globalThis.Headers;
 
 describe("FetchHttpClient", () => {
     beforeEach(() => {
-        globalThis.fetch;
+        // KLUDGE: Since JSDom doesn't support the Fetch API,
+        //         it doesn't have a Headers object, so define
+        //         one just for this test.
+        globalThis.Headers = FakeFetchHeaders;
+
         jest.spyOn(globalThis, "fetch").mockImplementation(
             async (input, init) => {
                 if (typeof input !== "string") {
@@ -20,6 +28,21 @@ describe("FetchHttpClient", () => {
                     }) as unknown as Response;
                 }
 
+                if (init?.headers) {
+                    const headers = init?.headers as FakeFetchHeaders;
+                    if (headers.has("x-ms-command-name")) {
+                        return new MockHttpResponse(input, {
+                            status: 200,
+                            body:
+                                "fake response with command name: " +
+                                headers.get("x-ms-command-name"),
+                            headers: {
+                                "Content-Type": "text/plain",
+                            },
+                        }) as unknown as Response;
+                    }
+                }
+
                 return new MockHttpResponse(input, {
                     status: 200,
                     body: "fake response",
@@ -33,6 +56,7 @@ describe("FetchHttpClient", () => {
 
     afterEach(() => {
         jest.restoreAllMocks();
+        globalThis.Headers = RealHeaders;
     });
 
     test("simple url request", async () => {
@@ -50,6 +74,19 @@ describe("FetchHttpClient", () => {
             body: "foobar",
         });
         expect(await response.text()).toBe("fake response with body");
+    });
+
+    test("custom headers", async () => {
+        const client = new FetchHttpClient();
+
+        const response = await client.fetch("/dogs/parker", {
+            metadata: {
+                commandName: "GetDog",
+            },
+        });
+        expect(await response.text()).toBe(
+            "fake response with command name: GetDog"
+        );
     });
 
     test("url is required", () => {
@@ -71,3 +108,68 @@ describe("FetchHttpClient", () => {
         ).rejects.toEqual(new Error("Fetch failed: Cannot specify two URLs"));
     });
 });
+
+/**
+ * A very limited/incomplete fake for the fetch headers object, since JSDom
+ * doesn't support the fetch API yet.
+ */
+export class FakeFetchHeaders implements Headers {
+    private _mapHttpHeaders: MapHttpHeaders;
+
+    constructor(headers?: HeadersInit) {
+        const headersInit: Record<string, string> = {};
+
+        if (headers && typeof headers === "object") {
+            for (const entry of Object.entries(headers)) {
+                const key = entry[0];
+                const value = entry[1];
+                if (typeof key === "string" && typeof value === "string") {
+                    headersInit[key] = value;
+                } else {
+                    throw new Error(
+                        "Fake fetch headers only supports string keys and values"
+                    );
+                }
+            }
+        }
+        this._mapHttpHeaders = new MapHttpHeaders(headersInit);
+    }
+    append(name: string, value: string): void {
+        this._mapHttpHeaders.append(name, value);
+    }
+    delete(name: string): void {
+        this._mapHttpHeaders.delete(name);
+    }
+    get(name: string): string | null {
+        return this._mapHttpHeaders.get(name);
+    }
+    has(name: string): boolean {
+        return this._mapHttpHeaders.has(name);
+    }
+    set(name: string, value: string): void {
+        this._mapHttpHeaders.set(name, value);
+    }
+    forEach(
+        callbackfn: (value: string, key: string, parent: Headers) => void,
+        thisArg?: unknown
+    ): void {
+        const cb = callbackfn as unknown as (
+            value: string,
+            key: string,
+            parent: HttpHeaders
+        ) => void;
+        return this._mapHttpHeaders.forEach(cb);
+    }
+    entries(): IterableIterator<[string, string]> {
+        throw new Error("Method not implemented.");
+    }
+    keys(): IterableIterator<string> {
+        throw new Error("Method not implemented.");
+    }
+    values(): IterableIterator<string> {
+        throw new Error("Method not implemented.");
+    }
+    [Symbol.iterator](): IterableIterator<[string, string]> {
+        throw new Error("Method not implemented.");
+    }
+}

--- a/packages/common/src/ui-common/http/constants.ts
+++ b/packages/common/src/ui-common/http/constants.ts
@@ -9,3 +9,7 @@ export enum HttpRequestMethod {
     Options = "OPTIONS",
     Trace = "TRACE",
 }
+
+export enum CustomHttpHeaders {
+    CommandName = "x-ms-command-name",
+}

--- a/packages/common/src/ui-common/http/fetch-http-client.ts
+++ b/packages/common/src/ui-common/http/fetch-http-client.ts
@@ -1,3 +1,4 @@
+import { CustomHttpHeaders } from "./constants";
 import { AbstractHttpClient, HttpRequestInit } from "./http-client";
 
 /**
@@ -49,6 +50,17 @@ export class FetchHttpClient extends AbstractHttpClient {
                     }
                 }
                 headers = new Headers(headersInit);
+            }
+
+            const commandName = req.metadata?.commandName;
+            if (commandName) {
+                if (!headers) {
+                    headers = new Headers({
+                        [CustomHttpHeaders.CommandName]: commandName,
+                    });
+                } else {
+                    headers.set(CustomHttpHeaders.CommandName, commandName);
+                }
             }
 
             responsePromise = fetch(url, {

--- a/packages/common/src/ui-common/http/http-client.ts
+++ b/packages/common/src/ui-common/http/http-client.ts
@@ -148,11 +148,25 @@ export interface HttpClient {
     ): Promise<HttpResponse>;
 }
 
+export interface HttpRequestMetadata {
+    /**
+     * Used to associate a friendly operation name with an HTTP request.
+     */
+    commandName: string;
+}
+
 export interface HttpRequestInit {
     body?: Blob | ArrayBuffer | ArrayBufferView | string;
     headers?: HttpHeaders | Record<string, string>;
     method?: string;
     url?: string;
+
+    /**
+     * Additional data passed to the HTTP Client along with the request.
+     * Different clients may handle this data differently, as it is not part
+     * of the actual HTTP request.
+     */
+    metadata?: HttpRequestMetadata;
 }
 
 export interface HttpResponse {


### PR DESCRIPTION
This can be used to add a friendly name to HTTP requests such as "CreateAccount" or "ScalePool" for debugging/logging purposes.