### PR TITLE
Luminosity contrast accessibility bugs (568, 569, 589) #2693

### DIFF
--- a/data/themes/classic.json
+++ b/data/themes/classic.json
@@ -18,7 +18,7 @@
   "border": "#919191",
   "editor": "vs",
   "text": {
-    "primary": "#333333",
+    "primary": "#323130",
     "secondary": "#666666"
   },
   "breadcrumb": {

--- a/data/themes/classic.json
+++ b/data/themes/classic.json
@@ -3,7 +3,7 @@
   "type": "standard",
   "primary": "#2F71C4",
   "primary-contrast": "#ffffff",
-  "danger": "#aa3939",
+  "danger": "#bc2f34",
   "danger-contrast": "#ffffff",
   "warn": "#a46026",
   "warn-contrast": "#ffffff",
@@ -53,16 +53,16 @@
     "disabled-bg": "#ededed"
   },
   "monitorChart": {
-    "core-count": "#1c3f95",
+    "core-count": "#004e8c",
     "low-priority-core-count": "#a36a00",
-    "task-start-event": "#a36a00",
-    "task-complete-event": "#428000",
-    "task-fail-event": "#aa3939",
-    "starting-node-count": "#1c3f95",
-    "idle-node-count": "#be93d9",
-    "running-node-count": "#428000",
-    "start-task-failed-node-count": "#aa3939",
-    "rebooting-node-count": "#ff755c"
+    "task-start-event": "#6d5700",
+    "task-complete-event": "#0f700f",
+    "task-fail-event": "#bc2f34",
+    "starting-node-count": "#004e8c",
+    "idle-node-count": "#8764b8",
+    "running-node-count": "#0f700f",
+    "start-task-failed-node-count": "#bc2f34",
+    "rebooting-node-count": "#d93c20"
   },
   "input": {
     "border": "#919191",
@@ -74,5 +74,5 @@
     "disabled-text": "var(--color-text-primary)",
     "disabled-background": "#e5e5e5"
   },
-  "chart-colors": ["#003f5c", "#aa3939", "#4caf50", "#ffa600"]
+  "chart-colors": ["#003f5c", "#bc2f34", "#4caf50", "#ffa600"]
 }

--- a/data/themes/dark.json
+++ b/data/themes/dark.json
@@ -14,6 +14,18 @@
     "primary": "#cccccc",
     "secondary": "#a7a8a9"
   },
+  "monitorChart": {
+    "core-count": "#0a95ff",
+    "low-priority-core-count": "#ae8c00",
+    "task-start-event": "#ae8c00",
+    "task-complete-event": "#0a95ff",
+    "task-fail-event": "#f26363",
+    "starting-node-count": "#0a95ff",
+    "idle-node-count": "#c674d2",
+    "running-node-count": "#44a744",
+    "start-task-failed-node-count": "#f26363",
+    "rebooting-node-count": "#db7843"
+  },
   "breadcrumb": {
     "text": "white",
     "background": "#5b5b5b",

--- a/src/@batch-flask/ui/form/form-field/form-field.scss
+++ b/src/@batch-flask/ui/form/form-field/form-field.scss
@@ -20,13 +20,21 @@ bl-form-field {
 
 
         > .input-prefix, > .input-suffix {
-            background: $input-border-color;
+            background: $secondary-background;
             border: 1px solid $input-border-color;
             height: 26px;
             padding: 0 5px;
             line-height: 26px;
             vertical-align: middle;
             color: $primary-text;
+        }
+
+        > .input-prefix {
+            border-right: none;
+        }
+
+        > .input-suffix {
+            border-left: none;
         }
     }
     .bl-form-field-label {}

--- a/src/app/components/account/monitoring/monitor-chart/monitor-chart.component.ts
+++ b/src/app/components/account/monitoring/monitor-chart/monitor-chart.component.ts
@@ -196,7 +196,8 @@ export class MonitorChartComponent implements OnChanges, OnDestroy {
             },
             tooltips: {
                 enabled: true,
-                mode: "index",
+                mode: "single",
+                position: "nearest",
                 callbacks: {
                     title: (tooltipItems, data) => {
                         return this._computeTooltipTitle(tooltipItems[0], data);

--- a/src/app/styles/vendor/material-theme.scss
+++ b/src/app/styles/vendor/material-theme.scss
@@ -30,6 +30,11 @@ $mat-theme: mat-light-theme($mat-primary, $mat-accent);
 
 mat-tab-group {
     .mat-tab-label {
+        opacity: 1;
+        color: $secondary-text;
+    }
+
+    .mat-tab-label-active {
         color: $primary-text;
     }
 }
@@ -40,9 +45,6 @@ mat-tab-group:not(.form-tabs) {
         border-right: 1px solid #ddd;
         height: 32px;
         line-height: 32px;
-
-        &.mat-tab-label-active {
-        }
 
         &.mat-tab-disabled {
             color: $button-disabled-text-color;


### PR DESCRIPTION
### Resolves:

- [Bug 568] [Visual Requirement-Batch Explorer-Add a batch account] Luminosity contrast ratio of the text "eastus.batch.azure.com" is less than 4.5:1 i.e 2.5:1.
- [Bug 569] [Visual Requirement-Batch Explorer-Node states] Luminosity contrast ratio of the text "Idle" is less than 4.5:1 i.e 2.5:1.
- [Bug 589] [Visual Requirement-Batch Explorer-Add a pool to the account] On the Add a pool to the account blade, luminosity contrast ratio of the text " Container" is less than 4.5:1 i.e 3.7:1.

### Notable changes:

- Updated colors of monitor chart and other parts of the UI on the dashboard for both classic and dark themes to have luminosity contrast ratio >=4.5:1 — bug above was specific to classic theme
- Update `primary` text color to a slightly darker color to pass the contrast test. This should affect all places using the `$primary-color`.
- Updated `.mat-tab-label` and `.mat-tab-label-active` to pass the contrast test. This should affect all instances of the material ui tables.
- Updated styles of bl-form-field to have luminosity contrast ratio >=4.5:1. This change affects all instances of `<bl-form-field>` that use `blFormFieldSuffix` or `blFormFieldPrefix`.
- Update tooltip configuration of the "Node states" chart to improve visibility. Please see my inline comment below for additional information.


--- 

Dashboard – classic theme:

![Screen Shot 2023-03-23 at 1 32 56 PM](https://user-images.githubusercontent.com/79171711/227361177-1460c62a-e4e5-4156-9329-3d659b642e71.png)

Dashboard – dark theme:

![Screen Shot 2023-03-23 at 1 32 17 PM](https://user-images.githubusercontent.com/79171711/227361214-44eb6954-f305-45fe-b1e6-5075ff7e4345.png)

Form fields with suffix – classic theme:

![Screen Shot 2023-03-23 at 1 51 15 PM](https://user-images.githubusercontent.com/79171711/227361273-43677fee-cec1-4183-9459-1e60079a428f.png)

Form fields with suffix – dark theme:

![Screen Shot 2023-03-23 at 2 07 06 PM](https://user-images.githubusercontent.com/79171711/227361666-fba6ede2-ab62-40c8-b012-0848cf9e9eff.png)

