### PR TITLE
Accessibility bug fixes (865, 950, 990, 702, 671)

### DIFF
--- a/src/@batch-flask/ui/buttons/button.scss
+++ b/src/@batch-flask/ui/buttons/button.scss
@@ -87,6 +87,15 @@ bl-button {
         width: $action-btn-size;
     }
 
+    &[type=square][color="primary"] {
+         &.focus-outline.focus-visible, &.focus-visible {
+            outline-color: white;
+            outline-width: 2px;
+            outline-style: solid;
+            outline-offset: -4px;
+        }
+    }
+
     &[type="round"] {
         border-radius: 99%;
 

--- a/src/@batch-flask/ui/select/select.component.ts
+++ b/src/@batch-flask/ui/select/select.component.ts
@@ -532,6 +532,7 @@ export class SelectComponent<TValue = any> implements FormFieldControl<any>, Opt
         } else if (isArrowKey && event.altKey || keyCode === ESCAPE) {
             // Close the select on ALT + arrow key to match the native <select>
             event.preventDefault();
+            event.stopPropagation();
             this.closeDropdown();
         } else if ((keyCode === ENTER || keyCode === SPACE) && navigator.focusedItem) {
             event.preventDefault();

--- a/src/@batch-flask/ui/table/table.scss
+++ b/src/@batch-flask/ui/table/table.scss
@@ -102,6 +102,11 @@ bl-table {
             }
         }
 
+        &.focused {
+            outline: 1px dashed $primary-color;
+            outline-offset: -2px;
+        }
+
         &.focused.selected {
             outline: 1px dashed $primary-contrast-color;
             outline-offset: -2px;

--- a/src/app/components/data/home/data-home.html
+++ b/src/app/components/data/home/data-home.html
@@ -4,7 +4,7 @@
     </div>
     <div blBrowseLayoutButtons>
         <bl-button type="plain" icon="fa fa-plus spin-hover" color="light" title="Add a file group" [matMenuTriggerFor]="addFileGroupMenu"
-            [disabled]="!hasAutoStorage" [@.disabled]="true">
+            (click)="addFileGroup()" (do)="addFileGroup()" [disabled]="!hasAutoStorage" [@.disabled]="true">
         </bl-button>
         <mat-menu #addFileGroupMenu="matMenu" [@.disabled]="true">
             <button mat-menu-item (click)="openEmptyContainerForm()"> Empty container </button>

--- a/src/app/components/pool/action/add/os-picker/os-offer-tile/os-offer-tile.scss
+++ b/src/app/components/pool/action/add/os-picker/os-offer-tile/os-offer-tile.scss
@@ -63,6 +63,9 @@ bl-os-offer-tile {
 
                 > .name {
                     text-transform: capitalize;
+                    display: inline-block;
+                    word-break: break-word;
+                    line-height: 1.3;
                 }
             }
 

--- a/src/app/styles/vendor/material-theme.scss
+++ b/src/app/styles/vendor/material-theme.scss
@@ -9,7 +9,7 @@
 // (imported above). For each palette, you can optionally specify a default, lighter, and darker
 // hue.
 $mat-primary: mat-palette($mat-indigo);
-$mat-accent:  mat-palette($mat-grey, A200, A100, A400);
+$mat-accent: mat-palette($mat-grey, A200, A100, A400);
 
 // Create the theme object (a Sass map containing all of the palettes).
 $mat-theme: mat-light-theme($mat-primary, $mat-accent);
@@ -74,13 +74,22 @@ mat-icon.mat-icon {
 mat-radio-button {
     margin-right: 15px;
 
+    &.cdk-keyboard-focused {
+        .mat-focus-indicator {
+            border-radius: 100%;
+            background-color: $primary-color-light;
+            opacity: 0.25;
+            z-index: -1;
+        }
+    }
+
     &.mat-radio-checked {
         .mat-radio-outer-circle {
-            border-color: $primary-color;
+            border-color: $primary-color !important;
         }
 
         .mat-radio-inner-circle {
-            background: $primary-color;
+            background: $primary-color !important;
         }
     }
 }
@@ -130,7 +139,7 @@ bl-form-field.bl-textarea {
 }
 
 .mat-autocomplete-panel {
-    max-width : 30vw;
+    max-width: 30vw;
 
     .mat-option {
         height: 24px;
@@ -173,17 +182,17 @@ mat-button-toggle-group {
     }
 }
 
-
-.mat-drawer-container, .mat-drawer {
+.mat-drawer-container,
+.mat-drawer {
     color: $primary-text;
     background-color: $main-background;
 }
 
-
 .mat-menu-item {
     height: 30px !important;
     line-height: 30px !important;
-    &.cdk-program-focused, &.cdk-keyboard-focused {
+    &.cdk-program-focused,
+    &.cdk-keyboard-focused {
         border: 1px solid $outline-color;
     }
 }


### PR DESCRIPTION
## Resolves:

- [865] [Keyboard Navigation-Azure Batch Explorer-Add a Pool]: Visual focus indicator is not visible for the multiple controls, while navigating using Tab key.
- [950] [Screen Readers-Azure Batch Explorer-Job>>Disable]: Visual focus indicator is not visible for the 'radio' buttons, while navigating using TAB key under the disable dialog.
- [990] [Screen Reader-Batch Explorer-Add button]: Focus moves to background while "Create a new empty container" pop-up is open.
- [702] [Keyboard Navigation - Batch Explore - Pools]: Focus order is not logical after refresh control under "Node" on "Pools" page. 
- [671] [Keyboard Navigation - Batch Explore - Add a batch account]: While closing the subscription dropdown whole dialog is getting close with esc key.

## Notable changes:

- `keydown` events handled by the `select` component no longer propagates
- Square buttons with primary colors now have a white focus ring
  <img width="181" alt="Screenshot 2023-04-07 at 3 18 20 PM" src="https://user-images.githubusercontent.com/79171711/230685710-3a402fb0-e238-4562-a60e-501f4c8720df.png">
- Style improvements for focused and selected states of `mat-radio-button`
  <img width="433" alt="Screenshot 2023-04-07 at 3 19 26 PM" src="https://user-images.githubusercontent.com/79171711/230685795-77f54a25-2998-4379-9a87-2ee6898fbd8a.png">

  






