### PR TITLE
Accessibility fix for bug 788 ("delete metadata row" tooltip)

### DIFF
--- a/src/@batch-flask/ui/form/editable-table/editable-table.html
+++ b/src/@batch-flask/ui/form/editable-table/editable-table.html
@@ -24,7 +24,7 @@
                 </td>
                 <td class="action-column">
                     <bl-clickable *ngIf="!isLast" class="delete-item-btn" [attr.aria-label]="'editable-table.deleteRow' | i18n"
-                        (do)="deleteItem(i)">
+                        (do)="deleteItem(i)" title="delete metadata row">
                         <i class="fa fa-times" aria-hidden="true"></i>
                     </bl-clickable>
                 </td>


### PR DESCRIPTION
Fix for [AB#788](https://azurebatch.visualstudio.com/3426cbfe-4c9a-4da4-88df-70f025a77017/_workitems/edit/788) [Visual Requirement-Batch Explorer-Edit Metadata] Incorrect tooltip is define for delete metadata row icon under Edit metadata blade.