### PR TITLE
Accessibility Bug Fixes (461, 573, 604, 605, 778)

### DIFF
--- a/src/@batch-flask/ui/buttons/button.component.spec.ts
+++ b/src/@batch-flask/ui/buttons/button.component.spec.ts
@@ -53,8 +53,9 @@ describe("ButtonComponent", () => {
     });
 
     it("Should have the tooltip specified with title", () => {
-        const el = de.query(By.css(".action-btn"));
-        expect(el.nativeElement.title).toBe("Stop");
+        expect(de.attributes["aria-label"]).toBe("Stop");
+        const tooltipTrigger = de.query(By.css(".mat-tooltip-trigger"));
+        expect(tooltipTrigger).not.toBeFalsy();
     });
 
     it("should change color", () => {

--- a/src/@batch-flask/ui/buttons/button.component.ts
+++ b/src/@batch-flask/ui/buttons/button.component.ts
@@ -77,6 +77,12 @@ export class ButtonComponent extends ClickableComponent {
         }
     }
 
+    // Removing the title attribute from the button because matTooltip is used
+    // to display the title. This is to prevent the user-agent tooltip from
+    // showing up on hover which will cause double tooltips. matTooltip will
+    // also apply an aria-label attribute to the button for accessibilty.
+    @Input() @HostBinding("attr.title") titleAttr: string = ""
+
     @ViewChild(MatTooltip, { static: false }) private _tooltip: MatTooltip;
 
     private _status = SubmitStatus.Idle;

--- a/src/@batch-flask/ui/buttons/button.html
+++ b/src/@batch-flask/ui/buttons/button.html
@@ -1,4 +1,4 @@
-<div class="action-btn" [ngClass]="type" title="{{tooltipTitle}}">
+<div class="action-btn" [ngClass]="type" matTooltip="{{tooltipTitle}}" matTooltipClass="btn-tooltip">
     <div [class.hide]="status !== SubmitStatus.Idle" class="label">
         <i [class]="icon" aria-hidden="true"></i>
         <ng-content></ng-content>

--- a/src/@batch-flask/ui/buttons/button.scss
+++ b/src/@batch-flask/ui/buttons/button.scss
@@ -174,7 +174,7 @@ bl-button {
 }
 
 .btn-tooltip {
-    font-size: 11px !important
+    font-size: $font-size-small !important
 }
 
 @media (forced-colors: active) {

--- a/src/@batch-flask/ui/buttons/button.scss
+++ b/src/@batch-flask/ui/buttons/button.scss
@@ -173,6 +173,10 @@ bl-button {
     }
 }
 
+.btn-tooltip {
+    font-size: 11px !important
+}
+
 @media (forced-colors: active) {
     bl-button {
         border: 1px solid currentColor;

--- a/src/@batch-flask/ui/buttons/clickable/clickable.component.ts
+++ b/src/@batch-flask/ui/buttons/clickable/clickable.component.ts
@@ -35,6 +35,8 @@ export class ClickableComponent implements OnChanges, OnDestroy {
      */
     @Input() public permission?: Permission;
 
+    @Input() public matTooltip?: string;
+
     /**
      * @returns true if either the disabled attribute is set to true or there is no permission for this action
      */

--- a/src/@batch-flask/ui/form/editable-table/editable-table.component.ts
+++ b/src/@batch-flask/ui/form/editable-table/editable-table.component.ts
@@ -120,6 +120,10 @@ export class EditableTableComponent implements ControlValueAccessor, Validator, 
         return index;
     }
 
+    public getHeaderIdForColumn(column: EditableTableColumnComponent) {
+        return `table-header-${column.name}`
+    }
+
     private _buildControlsFromValue(items: any[], columns: EditableTableColumnComponent[]) {
         if (Array.isArray(items) && items.length > 0) {
             const controls: FormGroup[] = Object.values(this.items.controls).slice(0, items.length) as any;

--- a/src/@batch-flask/ui/form/editable-table/editable-table.html
+++ b/src/@batch-flask/ui/form/editable-table/editable-table.html
@@ -3,7 +3,7 @@
     <table class="noselect" cellspacing="0" cellpadding="0" formArrayName="items" [attr.aria-label]="label" role="grid">
         <thead>
             <tr>
-                <th *ngFor="let column of columns;trackBy: trackColumn">
+                <th *ngFor="let column of columns;trackBy: trackColumn" [attr.id]="getHeaderIdForColumn(column)">
                     <ng-template [ngTemplateOutlet]="column.content"></ng-template>
                 </th>
                 <th class="action-column"></th>
@@ -18,7 +18,7 @@
                                 [rowValue]="item.value"></bl-editable-table-select-cell>
                         </ng-container>
                         <ng-container *ngSwitchDefault>
-                            <input [formControl]="item.controls[column.name]" [attr.type]="column.type" [attr.aria-placeholder]="column.name">
+                            <input [formControl]="item.controls[column.name]" [attr.type]="column.type" [attr.aria-describedby]="getHeaderIdForColumn(column)" [attr.aria-labeledby]="getHeaderIdForColumn(column)">
                         </ng-container>
                     </ng-container>
                 </td>

--- a/src/@batch-flask/ui/metrics-monitor/metrics-monitor.scss
+++ b/src/@batch-flask/ui/metrics-monitor/metrics-monitor.scss
@@ -24,16 +24,15 @@ bl-metrics-monitor {
             margin-left: 5px;
 
             > .label {
-                font-size: 11px;
+                font-size: $font-size-small;
                 line-height: 11px;
                 margin-bottom: 3px;
             }
 
             > .status {
-                font-size: 11px;
+                font-size: $font-size-small;
                 color: $secondary-text;
             }
-
         }
 
         > .graph {

--- a/src/@batch-flask/ui/quotas/quota-display/quota-display.scss
+++ b/src/@batch-flask/ui/quotas/quota-display/quota-display.scss
@@ -39,7 +39,7 @@ bl-quota-display {
 
     &[type="normal"] {
         > .details > .label {
-            font-size: 11px;
+            font-size: $font-size-small;
             height: 35%;
             margin: 3px 5px 0;
         }

--- a/src/@batch-flask/ui/tags/tag-list/tag-list.scss
+++ b/src/@batch-flask/ui/tags/tag-list/tag-list.scss
@@ -5,7 +5,7 @@ bl-tag-list {
     align-items: center;
 
     .tag {
-        font-size: 11px;
+        font-size: $font-size-small;
         color: $primary-contrast-color;
         background: $primary-color;
         padding: 0 5px;

--- a/src/@batch-flask/ui/toolbar/toolbar.scss
+++ b/src/@batch-flask/ui/toolbar/toolbar.scss
@@ -22,7 +22,7 @@ bl-toolbar {
     > [toolbarLabel] {
         display: inline-block;
         flex: 1;
-        font-size: 11px;
+        font-size: $font-size-small;
         color: $secondary-text;
         font-weight: 700;
         user-select: none;

--- a/src/app/components/gallery/application-list/gallery-application-list.html
+++ b/src/app/components/gallery/application-list/gallery-application-list.html
@@ -7,7 +7,8 @@
     class="application"
     [class.active]="application.id === active?.applicationId && application.portfolioId === active?.portfolioId"
     [attr.aria-selected]="application.id === active?.applicationId && application.portfolioId === active?.portfolioId"
-    [title]="application.description"
+    [matTooltip]="application.description"
+    matTooltipClass="tooltip"
     (do)="selectApplication(application)">
     <img class="logo" [src]="application.icon" alt="Logo of {{application.name}}">
     <div class="name">{{application.name}}</div>

--- a/src/app/components/gallery/application-list/gallery-application-list.scss
+++ b/src/app/components/gallery/application-list/gallery-application-list.scss
@@ -47,6 +47,6 @@ bl-gallery-application-list {
     }
 
     .tooltip {
-        font-size: 11px;
+        font-size: $font-size-small;
     }
 }

--- a/src/app/components/gallery/application-list/gallery-application-list.scss
+++ b/src/app/components/gallery/application-list/gallery-application-list.scss
@@ -1,6 +1,5 @@
 @import "app/styles/variables";
 
-
 bl-gallery-application-list {
     .application {
         vertical-align: bottom;
@@ -45,5 +44,9 @@ bl-gallery-application-list {
             height: 140px;
             width: 140px;
         }
+    }
+
+    .tooltip {
+        font-size: 11px;
     }
 }

--- a/src/app/components/layout/pinned-entity-dropdown/pinned-dropdown.html
+++ b/src/app/components/layout/pinned-entity-dropdown/pinned-dropdown.html
@@ -18,7 +18,7 @@
                     <i *ngIf="favorite.url === currentUrl" class="extra fa fa-check"></i>
                 </span>
             </bl-clickable>
-            <bl-clickable class="dropdown-item delete" (do)="removeFavorite(favorite)">
+            <bl-clickable class="dropdown-item delete" (do)="removeFavorite(favorite)" title="Remove from favorites" name="remove">
                 <i class="fa fa-times"  aria-hidden="true"></i>
             </bl-clickable>
         </div>

--- a/src/app/components/pool/action/add/app-license-picker/app-license-picker.scss
+++ b/src/app/components/pool/action/add/app-license-picker/app-license-picker.scss
@@ -9,7 +9,6 @@ bl-app-license-picker {
             color: #333333;
 
             > .summary-container {
-
                 &.standard {
                     height: unset;
                 }
@@ -52,7 +51,7 @@ bl-app-license-picker {
     }
 
     .note {
-        font-size: 11px;
+        font-size: $font-size-small;
         font-weight: bold;
         padding-top: 5px;
     }
@@ -81,8 +80,8 @@ bl-app-license-picker {
     }
 
     ol li span {
-        font-weight:bold;
-        margin-right:5px;
+        font-weight: bold;
+        margin-right: 5px;
         border-bottom: 1px solid $primary-text;
     }
 }

--- a/src/app/styles/variables.scss
+++ b/src/app/styles/variables.scss
@@ -9,6 +9,7 @@ $link-color-hover           : $primary-color-dark;
 $validation-error-color     : $danger-color;
 
 
+$font-size-small    : 11px;
 $font-size-base     : 13px;
 $font-size-large    : 15px;
 $baseLineHeight     : 1.4em;


### PR DESCRIPTION
## Resolves

- [Bug 461] [Keyboard Navigation -Batch Explorer - 3DS Max] Tooltip content is not displayed on "3DS Max" button while navigating with keyboard.
- [Bug 604] [Programmatic Access-Batch Explorer- Gallery-Local template library] On the Set local folders containing your templates window, an incorrect structure is defined for the friendly name control.
- [Bug 605] [Screen Reader-Batch Explorer- Gallery-Local template library] On the Set local folders containing your templates window, the label (friendly name) is not associated with the control.
- [Bug 778] [Visual Requirement- Batch Explorer- Terminate button]: Tooltip is not visible on keyboard focus for terminate button.
- [Bug 573] [Programmatic Access-Batch Explorer-No favorite item pinned] Name is not defined for the control available inside the 1 favorite items pinned button.

## Notable Changes

### Tooltips on `bl-buttons`

This PR replaces native user-agent tooltips with mattooltips for all instances of `bl-button` to add proper keyboard support. 

<img width="389" alt="Screenshot 2023-04-26 at 3 40 07 PM" src="https://user-images.githubusercontent.com/79171711/234718008-dd6104c7-3d68-440c-8cc1-496cbaf5f3c1.png">

This also removes the `label` attributes on the button to prevent double tooltips from showing up now that tooltips are rendered by `mattooltips`:

<img width="349" alt="Screenshot 2023-04-19 at 2 04 18 PM" src="https://user-images.githubusercontent.com/79171711/234718146-9a7f2369-af4a-462a-840b-ed5f8653b3b5.png">

Although the `label` attribute is removed, `mattooltip` still applies `aria-label` with the same value as the label attribute so screen readers should still be able to announce the intended label.

<img width="755" alt="Screenshot 2023-04-26 at 3 44 15 PM" src="https://user-images.githubusercontent.com/79171711/234718531-8adbd488-99b3-4b63-8b18-d60c690f5ddb.png">

