### PR TITLE
Fix cloud service sku values for vm picker table

### DIFF
--- a/src/app/components/pool/action/add/vm-size-picker/vm-size-picker.component.ts
+++ b/src/app/components/pool/action/add/vm-size-picker/vm-size-picker.component.ts
@@ -84,6 +84,7 @@ export class VmSizePickerComponent implements ControlValueAccessor, OnInit, OnCh
     public prices: OSPricing = null;
     public categoriesDisplayName = categoriesDisplayName;
     public basicInput = new FormControl();
+    public isCloudService = false;
 
     public tableConfig: TableConfig = {
         sorting: {
@@ -135,8 +136,10 @@ export class VmSizePickerComponent implements ControlValueAccessor, OnInit, OnCh
             let sizes;
             if (this.osSource === PoolOsSources.IaaS) {
                 sizes = this.vmSizeService.virtualMachineSizes;
+                this.isCloudService = false;
             } else {
                 sizes = this.vmSizeService.cloudServiceSizes;
+                this.isCloudService = true;
             }
             this.loadingStatus = LoadingStatus.Loading;
             this._sizeSub = sizes.subscribe((x) => {

--- a/src/app/components/pool/action/add/vm-size-picker/vm-size-picker.html
+++ b/src/app/components/pool/action/add/vm-size-picker/vm-size-picker.html
@@ -32,7 +32,7 @@
                     <div *blCellDef="let size">{{size.prettyRAM}}</div>
                 </bl-column>
 
-                <bl-column name="osdisk" [sortable]="true" [defaultWidth]="70">
+                <bl-column name="osdisk" [sortable]="true" [defaultWidth]="70" *ngIf="!isCloudService">
                     <div *blHeadCellDef>OS Disk</div>
                     <div *blCellDef="let size">{{size.prettyOSDiskSize}}</div>
                 </bl-column>

--- a/src/app/models/vm-size.ts
+++ b/src/app/models/vm-size.ts
@@ -69,11 +69,11 @@ export function mapResourceSkuToVmSize(skuJson: any[]): List<VmSize> {
         const vmSize: Partial<VmSizeAttributes> = {};
         const capabilities = skuToCapabilities[skuName];
         vmSize.name = skuName;
-        vmSize.numberOfCores = _parseIntOrReturnDefault(capabilities.get("vCPUs"));
+        vmSize.numberOfCores = _parseIntOrReturnDefault(_getCapabilityDetails(capabilities, "vCPUs", "Cores"));
         vmSize.numberOfGpus = _parseIntOrReturnDefault(capabilities.get("GPUs"));
         vmSize.osDiskSizeInMB = _parseIntOrReturnDefault(capabilities.get("OSVhdSizeMB"));
-        vmSize.resourceDiskSizeInMB = _parseIntOrReturnDefault(capabilities.get("MaxResourceVolumeMB"));
-        vmSize.memoryInMB = _parseFloatOrReturnDefault(capabilities.get("MemoryGB")) * 1024;
+        vmSize.resourceDiskSizeInMB = _parseIntOrReturnDefault(_getCapabilityDetails(capabilities, "MaxResourceVolumeMB", "WebWorkerResourceDiskSizeInMb"));
+        vmSize.memoryInMB = _parseFloatOrReturnDefault(_getCapabilityDetails(capabilities, "MemoryGB", "MemoryInMb"));
         vmSize.maxDataDiskCount = _parseIntOrReturnDefault(capabilities.get("MaxDataDiskCount"));
         skuToVmSize.push(new VmSize(vmSize as VmSizeAttributes));
     }
@@ -90,6 +90,23 @@ function _getCapabilitiesMap(skuJson: any[]): any {
         }
     }
     return skuToCapabilities;
+}
+
+/**
+ * Gets capability value for either a virtual machine sku capability name or a cloud service sku
+ * capability name.
+ */
+function _getCapabilityDetails(capabilities, capabilityName: string, altCapabilityName: string) {
+    const vmCapability = capabilities.get(capabilityName);
+    const cloudServiceCapability = capabilities.get(altCapabilityName);
+    if (vmCapability) {
+        return vmCapability;
+    } else if (cloudServiceCapability) {
+        if (altCapabilityName === "MemoryInMb") {
+            return Math.round(parseInt(cloudServiceCapability) / 1024).toString();
+        }
+        return cloudServiceCapability;
+    }
 }
 
 function _parseIntOrReturnDefault(skuCapabilityValue : string): number {

--- a/src/app/models/vm-size.ts
+++ b/src/app/models/vm-size.ts
@@ -100,11 +100,11 @@ function _getCapabilityDetails(capabilities, capabilityName: string, altCapabili
     const vmCapability = capabilities.get(capabilityName);
     const cloudServiceCapability = capabilities.get(altCapabilityName);
     if (vmCapability) {
+        if (capabilityName === "MemoryGB") {
+            return Math.round((vmCapability) * 1024).toString();
+        }
         return vmCapability;
     } else if (cloudServiceCapability) {
-        if (altCapabilityName === "MemoryInMb") {
-            return Math.round(parseInt(cloudServiceCapability) / 1024).toString();
-        }
         return cloudServiceCapability;
     }
 }


### PR DESCRIPTION
Example of what the table looked like before, with all values set to 0:
![image](https://user-images.githubusercontent.com/16728220/235556829-3517fe99-443a-4be5-86be-a209e676ddcb.png)

Example of the table now with correct values:
- also removed the OS Disk table column for cloud service skus
![image](https://user-images.githubusercontent.com/16728220/235556732-a9d0fa41-7282-4021-9ae6-5d8142e27854.png)
