### PR TITLE
Fixes release deployment

### DIFF
--- a/desktop/tsconfig.scripts.json
+++ b/desktop/tsconfig.scripts.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "es6",
     "module": "commonjs",
+    "esModuleInterop": true
   },
   // This is not actually used for building but to let the editor know what files use this config
   "include": [


### PR DESCRIPTION
`update-latest.ts` used an external dependency (`make-dir`) which didn't produce a valid namespace export in TypeScript. Enabling `esModuleInterop` creates a shim to ensure namespace exports so that the script runs correctly during deployment.