### PR TITLE
Reorganizes ESLint rules in BatchExplorer

### DIFF
--- a/desktop/.eslintrc.desktop.json
+++ b/desktop/.eslintrc.desktop.json
@@ -2,12 +2,45 @@
   "extends": [
     "../util/common-config/.eslintrc-common.json"
   ],
+  "plugins": [
+    "@angular-eslint/eslint-plugin",
+    "@angular-eslint/eslint-plugin-template",
+    "@typescript-eslint"
+  ],
   "rules": {
     "@typescript-eslint/ban-types": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "no-case-declarations": "off",
     "no-extra-boolean-cast": "off",
-    "no-useless-escape": "off"
+    "no-useless-escape": "off",
+    "@angular-eslint/component-selector": [
+      "error",
+      {
+        "type": "element",
+        "prefix": [
+          "bl",
+          "be"
+        ],
+        "style": "kebab-case"
+      }
+    ],
+    "@angular-eslint/directive-selector": [
+      "error",
+      {
+        "type": "attribute",
+        "prefix": [
+          "bl",
+          "be"
+        ],
+        "style": "camelCase"
+      }
+    ],
+    "@angular-eslint/no-forward-ref": "off",
+    "@angular-eslint/no-input-rename": "warn",
+    "@angular-eslint/use-lifecycle-interface": "warn",
+    "@typescript-eslint/no-var-requires": "warn",
+    "@typescript-eslint/no-empty-interface": "warn",
+    "@typescript-eslint/ban-ts-comment": "warn"
   }
 }

--- a/desktop/.eslintrc.js
+++ b/desktop/.eslintrc.js
@@ -1,58 +1,21 @@
 module.exports = {
     ignorePatterns: [
         "node_modules/**/*",
-        "**/node_modules/**/*",
-        "lib/**/*",
-        "build/**/*",
-        "python/**/*",
-        "docs/**/*",
-        "data/**/*"
+        "/lib/**/*",
+        "/build/**/*",
+        "/python/**/*",
+        "/docs/**/*",
+        "/data/**/*"
     ],
     env: {
         browser: true,
         es6: true,
         node: true
     },
+    extends: [
+        ".eslintrc.desktop.json"
+    ],
     overrides: [
-        /*
-         * TYPESCRIPT FILES
-         */
-        {
-            files: ["src/**/*.ts"],
-            extends: [
-                ".eslintrc.desktop.json",
-                "prettier"
-            ],
-            plugins: [
-                "@angular-eslint/eslint-plugin",
-                "@angular-eslint/eslint-plugin-template",
-                "@typescript-eslint"
-            ],
-            rules: {
-                "@angular-eslint/component-selector": [
-                    "error",
-                    {
-                        type: "element",
-                        prefix: ["bl", "be"],
-                        style: "kebab-case"
-                    }
-                ],
-                "@angular-eslint/directive-selector": [
-                    "error",
-                    {
-                        type: "attribute",
-                        prefix: ["bl", "be"],
-                        style: "camelCase"
-                    }
-                ],
-                "@angular-eslint/no-forward-ref": "off",
-                "@angular-eslint/no-input-rename": "warn",
-                "@angular-eslint/use-lifecycle-interface": "warn",
-                "@typescript-eslint/no-var-requires": "warn",
-                "@typescript-eslint/no-empty-interface": "warn",
-                "@typescript-eslint/ban-ts-comment": "warn"
-            }
-        },
         /*
          * COMPONENT TEMPLATES
          */
@@ -95,10 +58,6 @@ module.exports = {
          */
         {
             files: ["scripts/**/*.ts", "config/**/*.ts"],
-            extends: [
-                ".eslintrc.desktop.json",
-                "prettier"
-            ],
             parserOptions: {
                 project: [
                     "tsconfig.eslint.json"
@@ -119,10 +78,10 @@ module.exports = {
                 "config/**/*.js",
                 "test/client/**/*.js",
                 "test/spectron/run.js",
-                "karma.conf.js"],
+                "karma.conf.js"
+            ],
             extends: [
-                "eslint:recommended",
-                "prettier"
+                "eslint:recommended"
             ],
             rules: {
                 "@typescript-eslint/no-var-requires": "off",

--- a/desktop/scripts/azpipelines/update-latest.ts
+++ b/desktop/scripts/azpipelines/update-latest.ts
@@ -19,11 +19,11 @@ const storageAccountName = process.env.AZURE_STORAGE_ACCOUNT;
 const storageAccountKey = process.argv[2];
 
 console.log("Artifact staging directory is", stagingDir);
-console.log(`##vso[task.setvariable variable=BE_GITHUB_ARTIFACTS_DIR]${stagingDir}`)
+console.log(`##vso[task.setvariable variable=BE_GITHUB_ARTIFACTS_DIR]${stagingDir}`);
 
 if (!storageAccountName) {
     console.error(`No storage account name found in AZURE_STORAGE_ACCOUNT`);
-    process.exit(-1)
+    process.exit(-1);
 }
 
 if (!storageAccountKey) {
@@ -88,7 +88,7 @@ async function copyAllFilesToArtifactStaging() {
 
 async function updateLatest(os) {
     const manifest = getManifest(os);
-    console.log(`##vso[task.setvariable variable=BE_RELEASE_VERSION]${manifest.version}`)
+    console.log(`##vso[task.setvariable variable=BE_RELEASE_VERSION]${manifest.version}`);
     console.log(`Updating latest for os: ${os}`);
     if (!manifest.buildType) {
         throw new Error(

--- a/desktop/scripts/azpipelines/utils.ts
+++ b/desktop/scripts/azpipelines/utils.ts
@@ -1,4 +1,13 @@
-import { BlobBeginCopyFromURLResponse, BlobDownloadResponseParsed, BlobGetPropertiesResponse, BlobUploadCommonResponse, BlockBlobClient, PollerLike, PollOperationState, StorageSharedKeyCredential } from "@azure/storage-blob";
+import {
+    BlobBeginCopyFromURLResponse,
+    BlobDownloadResponseParsed,
+    BlobGetPropertiesResponse,
+    BlobUploadCommonResponse,
+    BlockBlobClient,
+    PollerLike,
+    PollOperationState,
+    StorageSharedKeyCredential
+} from "@azure/storage-blob";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -63,7 +72,7 @@ export class BlobStorageClient {
         return new BlockBlobClient(
             storageURL(this.accountName, container, blob),
             this.credential
-        )
+        );
     }
 
     public getUrl(container: string, blob: string): string {
@@ -101,6 +110,6 @@ export class BlobStorageClient {
             onProgress(state) {
                 console.log(`Copy "${blob}" is pending ${state.copyProgress}`);
             },
-        })
+        });
     }
 }

--- a/desktop/scripts/lca/generate-third-party.ts
+++ b/desktop/scripts/lca/generate-third-party.ts
@@ -141,7 +141,7 @@ async function loadLicense(dependency: Dependency, anonymous = false):
     const repoName = getRepoName(repoUrl);
     const licenseUrl = `https://api.github.com/repos/${repoName}/license`;
     const headers: HeaderInit = anonymous ? {} :
-        { Authorization: `token ${process.env.GH_TOKEN}` }
+        { Authorization: `token ${process.env.GH_TOKEN}` };
 
     return fetch(licenseUrl, { headers }).then(async (res) => {
         /** Will look up default license if cannot find a license */
@@ -156,7 +156,7 @@ async function loadLicense(dependency: Dependency, anonymous = false):
         return await res.json();
     }).catch((error) => {
         console.error(`Error loading license for ${repoName}`, error);
-        process.exit(1)
+        process.exit(1);
     });
 }
 

--- a/desktop/src/@batch-flask/core/aad/access-token-cache/access-token-cache.spec.ts
+++ b/desktop/src/@batch-flask/core/aad/access-token-cache/access-token-cache.spec.ts
@@ -35,7 +35,7 @@ describe("AccessTokenCache", () => {
         expect(cache.hasToken("tenant1", "resource1")).toBeFalsy();
         expect(cache.hasToken("tenant1", "resource2")).toBeFalsy();
 
-        cache.removeToken("tenant2", "resource1")
+        cache.removeToken("tenant2", "resource1");
         expect(cache.hasToken("tenant2", null)).toBeTruthy();
         expect(cache.hasToken("tenant2", "resource1")).toBeFalsy();
         expect(cache.hasToken("tenant2", "resource2")).toBeTruthy();

--- a/desktop/src/@batch-flask/core/html-util/focus-helper.spec.ts
+++ b/desktop/src/@batch-flask/core/html-util/focus-helper.spec.ts
@@ -69,6 +69,6 @@ describe("focus-helper", () => {
             children[1].setAttribute("disabled", true);
             children[2].tabIndex = 0;
             expectContainerFocus(children[2]);
-        })
+        });
     });
 });

--- a/desktop/src/@batch-flask/ui/callout/callout.directive.ts
+++ b/desktop/src/@batch-flask/ui/callout/callout.directive.ts
@@ -49,7 +49,7 @@ export class CalloutDirective {
                 this.close();
                 this.elementRef.nativeElement.focus();
             }
-        }
+        };
         focusWithin(this._overlayRef.overlayElement);
     }
 

--- a/desktop/src/@batch-flask/ui/form/complex-form/complex-form.component.ts
+++ b/desktop/src/@batch-flask/ui/form/complex-form/complex-form.component.ts
@@ -99,7 +99,7 @@ export class ComplexFormComponent extends FormBase implements AfterViewInit, OnC
         this.changeDetector.detectChanges();
         setTimeout(() => {
             this.focusFirstFocusableElement();
-        })
+        });
     }
 
     public ngOnChanges(changes) {
@@ -175,7 +175,7 @@ export class ComplexFormComponent extends FormBase implements AfterViewInit, OnC
         this.currentPage = page;
 
         setTimeout(() => {
-            this.focusFirstFocusableElement()
+            this.focusFirstFocusableElement();
         });
     }
 
@@ -279,6 +279,6 @@ export class ComplexFormComponent extends FormBase implements AfterViewInit, OnC
     }
 
     private focusFirstFocusableElement() {
-        this.formElement.nativeElement?.querySelector('[autofocus], button, input, textarea, select')?.focus()
+        this.formElement.nativeElement?.querySelector('[autofocus], button, input, textarea, select')?.focus();
     }
 }

--- a/desktop/src/@batch-flask/ui/form/editable-table/editable-table.component.ts
+++ b/desktop/src/@batch-flask/ui/form/editable-table/editable-table.component.ts
@@ -121,7 +121,7 @@ export class EditableTableComponent implements ControlValueAccessor, Validator, 
     }
 
     public getHeaderIdForColumn(column: EditableTableColumnComponent) {
-        return `table-header-${column.name}`
+        return `table-header-${column.name}`;
     }
 
     private _buildControlsFromValue(items: any[], columns: EditableTableColumnComponent[]) {

--- a/desktop/src/app/components/account/browse/account-list/account-list.component.ts
+++ b/desktop/src/app/components/account/browse/account-list/account-list.component.ts
@@ -57,7 +57,7 @@ export class AccountListComponent extends ListBaseComponent implements OnDestroy
 
     @autobind()
     public refresh(): Observable<any> {
-        return this.accountService.loadSubscriptionsAndAccounts()
+        return this.accountService.loadSubscriptionsAndAccounts();
     }
 
     public handleFilter(filter: Filter) {

--- a/desktop/src/app/components/common/react-container/react-container.component.ts
+++ b/desktop/src/app/components/common/react-container/react-container.component.ts
@@ -9,7 +9,7 @@ import {
 } from "@angular/core";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import {RootPane} from "@batch/ui-react/lib/components/layout"
+import {RootPane} from "@batch/ui-react/lib/components/layout";
 import { Subscription } from "rxjs";
 import { Theme, ThemeService } from "app/services";
 

--- a/desktop/src/app/components/layout/main-navigation/profile-button/profile-button.component.spec.ts
+++ b/desktop/src/app/components/layout/main-navigation/profile-button/profile-button.component.spec.ts
@@ -149,10 +149,10 @@ describe("ProfileButtonComponent", () => {
                 if (label) {
                     expect(menuItem.label).toEqual(label);
                 }
-            }
+            };
 
-            expectMenuItem(ContextMenuItem, "Check for updates")
-            expectMenuItem(ContextMenuSeparator)
+            expectMenuItem(ContextMenuItem, "Check for updates");
+            expectMenuItem(ContextMenuSeparator);
             expectMenuItem(ContextMenuItem, "profile-button.settings");
             expectMenuItem(ContextMenuItem, "profile-button.authentication");
             expectMenuItem(ContextMenuItem, "profile-button.keybindings");

--- a/desktop/src/app/components/settings/auth-settings/auth-settings.module.ts
+++ b/desktop/src/app/components/settings/auth-settings/auth-settings.module.ts
@@ -5,7 +5,7 @@ import { AuthSettingsComponent } from "./auth-settings.component";
 
 const components = [ AuthSettingsComponent ];
 
-const modules = [ TenantPickerModule ]
+const modules = [ TenantPickerModule ];
 
 @NgModule({
     declarations: components,

--- a/desktop/src/app/components/tenant-picker/tenant-card.component.ts
+++ b/desktop/src/app/components/tenant-picker/tenant-card.component.ts
@@ -65,6 +65,6 @@ export class TenantCardComponent implements OnDestroy, OnChanges {
         this.refreshTenant.emit({
             tenantId: this.tenant.tenantId,
             reauthenticate
-        })
+        });
     }
 }

--- a/desktop/src/app/components/tenant-picker/tenant-picker.component.ts
+++ b/desktop/src/app/components/tenant-picker/tenant-picker.component.ts
@@ -58,7 +58,7 @@ export class TenantPickerComponent implements ControlValueAccessor, OnDestroy {
             if (data.tenantId) {
                 reauthenticate = data.tenantId;
             } else {
-                reauthenticate = reauthenticateAll
+                reauthenticate = reauthenticateAll;
             }
         }
 

--- a/desktop/src/app/models/vm-size.ts
+++ b/desktop/src/app/models/vm-size.ts
@@ -72,7 +72,11 @@ export function mapResourceSkuToVmSize(skuJson: any[]): List<VmSize> {
         vmSize.numberOfCores = _parseIntOrReturnDefault(_getCapabilityDetails(capabilities, "vCPUs", "Cores"));
         vmSize.numberOfGpus = _parseIntOrReturnDefault(capabilities.get("GPUs"));
         vmSize.osDiskSizeInMB = _parseIntOrReturnDefault(capabilities.get("OSVhdSizeMB"));
-        vmSize.resourceDiskSizeInMB = _parseIntOrReturnDefault(_getCapabilityDetails(capabilities, "MaxResourceVolumeMB", "WebWorkerResourceDiskSizeInMb"));
+        vmSize.resourceDiskSizeInMB =
+            _parseIntOrReturnDefault(
+                _getCapabilityDetails(capabilities, "MaxResourceVolumeMB",
+                    "WebWorkerResourceDiskSizeInMb")
+            );
         vmSize.memoryInMB = _parseFloatOrReturnDefault(_getCapabilityDetails(capabilities, "MemoryGB", "MemoryInMb"));
         vmSize.maxDataDiskCount = _parseIntOrReturnDefault(capabilities.get("MaxDataDiskCount"));
         skuToVmSize.push(new VmSize(vmSize as VmSizeAttributes));

--- a/desktop/src/app/services/aad/auth.service.spec.ts
+++ b/desktop/src/app/services/aad/auth.service.spec.ts
@@ -11,7 +11,7 @@ const FakeTenants = {
     One: "tenant-1",
     Two: "tenant-2",
     Three: "tenant-3",
-}
+};
 const resource1 = "batch";
 const token1 = new AccessToken({
     accessToken: "sometoken",

--- a/desktop/src/app/services/aad/auth.service.ts
+++ b/desktop/src/app/services/aad/auth.service.ts
@@ -100,7 +100,7 @@ export class AuthService implements OnDestroy {
                     active: tenant.homeTenantId === tenant.tenantId ||
                         settings[tenant.tenantId] === "active",
                     status: TenantStatus.unknown
-                } as TenantAuthorization))
+                } as TenantAuthorization));
             }),
             switchMap(authorizations => forkJoin(authorizations.map(
                 authorization =>

--- a/desktop/src/app/services/compute/vm-size.service.spec.ts
+++ b/desktop/src/app/services/compute/vm-size.service.spec.ts
@@ -39,8 +39,8 @@ describe("VMSizeService", () => {
     const westusCloudServiceQuery = `/subscriptions/${testWestusAccount.subscription.subscriptionId}/providers/Microsoft.Batch/locations/${testWestusAccount.location}/cloudServiceSkus?api-version=2021-06-01`;
     const westusVMQuery = `/subscriptions/${testWestusAccount.subscription.subscriptionId}/providers/Microsoft.Batch/locations/${testWestusAccount.location}/virtualMachineSkus?api-version=2021-06-01`;
     // brazilsouth account
-    const brazilCloudServiceQuery = `/subscriptions/${testBrazilAccount.subscription.subscriptionId}/providers/Microsoft.Batch/locations/${testBrazilAccount.location}/cloudServiceSkus?api-version=2021-06-01`
-    const brazilVMQuery = `/subscriptions/${testBrazilAccount.subscription.subscriptionId}/providers/Microsoft.Batch/locations/${testBrazilAccount.location}/virtualMachineSkus?api-version=2021-06-01`
+    const brazilCloudServiceQuery = `/subscriptions/${testBrazilAccount.subscription.subscriptionId}/providers/Microsoft.Batch/locations/${testBrazilAccount.location}/cloudServiceSkus?api-version=2021-06-01`;
+    const brazilVMQuery = `/subscriptions/${testBrazilAccount.subscription.subscriptionId}/providers/Microsoft.Batch/locations/${testBrazilAccount.location}/virtualMachineSkus?api-version=2021-06-01`;
 
     beforeEach(() => {
         armSpy = {

--- a/desktop/src/app/services/compute/vm-size.service.ts
+++ b/desktop/src/app/services/compute/vm-size.service.ts
@@ -12,7 +12,7 @@ import { mapResourceSkuToVmSize } from "../../models/vm-size";
 const includedVmsSizesPath = "data/vm-sizes-list.json";
 
 export function supportedSkusUrl(subscriptionId: string, location: string) {
-    return `/subscriptions/${subscriptionId}/providers/Microsoft.Batch/locations/${location}`
+    return `/subscriptions/${subscriptionId}/providers/Microsoft.Batch/locations/${location}`;
 }
 
 interface VmSizeCategories {
@@ -243,7 +243,7 @@ export class VmSizeService implements OnDestroy {
                 if (!(account instanceof ArmBatchAccount)) {
                     return of(null);
                 } else {
-                    const cloudServiceUrl = `${supportedSkusUrl(account.subscription.subscriptionId, account.location)}/cloudServiceSkus?api-version=2021-06-01`
+                    const cloudServiceUrl = `${supportedSkusUrl(account.subscription.subscriptionId, account.location)}/cloudServiceSkus?api-version=2021-06-01`;
                     return this._fetchVmSkusForAccount(account, cloudServiceUrl);
                 }
             }),
@@ -257,7 +257,7 @@ export class VmSizeService implements OnDestroy {
                 if (!(account instanceof ArmBatchAccount)) {
                     return of(null);
                 } else {
-                    const vmUrl = `${supportedSkusUrl(account.subscription.subscriptionId, account.location)}/virtualMachineSkus?api-version=2021-06-01`
+                    const vmUrl = `${supportedSkusUrl(account.subscription.subscriptionId, account.location)}/virtualMachineSkus?api-version=2021-06-01`;
                     return this._fetchVmSkusForAccount(account, vmUrl);
                 }
             }),

--- a/desktop/src/app/services/compute/vmsize_sample_responses.ts
+++ b/desktop/src/app/services/compute/vmsize_sample_responses.ts
@@ -90,7 +90,7 @@ export const cloudServiceResponse = {
             "family": "standardDFamily"
         }
     ]
-}
+};
 
 export const virtualMachineResponse = {
     "value": [
@@ -186,7 +186,7 @@ export const virtualMachineResponse = {
             "family": "standardDFamily"
         }
     ]
-}
+};
 
 export const badResponseIsNaN = {
     "value": [

--- a/desktop/src/app/utils/pool-utils.ts
+++ b/desktop/src/app/utils/pool-utils.ts
@@ -35,7 +35,7 @@ const deprecatedContainerImages = [
     "datacenter-core-20h2-with-containers-smalldisk",
     "datacenter-core-20h2-with-containers-smalldisk-gs",
     "datacenter-core-20h2-with-containers-smalldisk-g2",
-]
+];
 
 const iconMapping = {
     "ubuntuserver": Icons.ubuntu,

--- a/desktop/src/client/core/aad/auth-provider.spec.ts
+++ b/desktop/src/client/core/aad/auth-provider.spec.ts
@@ -185,7 +185,7 @@ const makeTokenCacheSpy = () => jasmine.createSpyObj(
         getAllAccounts: [],
         remove: jasmine.anything
     }
-)
+);
 
 const makeClientApplicationSpy = () => jasmine.createSpyObj(
     "ClientApplication", {

--- a/desktop/src/client/core/aad/auth-provider.ts
+++ b/desktop/src/client/core/aad/auth-provider.ts
@@ -101,7 +101,7 @@ export default class AuthProvider {
                 );
                 code = await authCodeCallback(url, tenantId, true);
             } catch (silentAuthException) {
-                log.debug(`[${tenantId}] Silent auth failed (${silentAuthException})`)
+                log.debug(`[${tenantId}] Silent auth failed (${silentAuthException})`);
                 if (silentAuthException instanceof AuthorizeError &&
                     !this._isTenantAuthRetryable(silentAuthException)) {
                     log.warn(`Fatal authentication exception for ${tenantId}:` +

--- a/desktop/src/client/core/aad/authentication/authentication.service.spec.ts
+++ b/desktop/src/client/core/aad/authentication/authentication.service.spec.ts
@@ -17,7 +17,7 @@ const CONFIG = {
 const FAKE_TOKEN = {
     accessToken: "somecode",
     account: { username: "user@contoso.com" } as AccountInfo
-}
+};
 
 describe("AuthenticationService", () => {
     let userAuthorization: AuthenticationService;
@@ -97,7 +97,7 @@ describe("AuthenticationService", () => {
                 error: "someerror",
                 description: "There was an error",
                 errorCodes: [ unretryableAuthCodeErrors[0] ]
-            }
+            };
             await promise;
 
             expect(result).toBeNull();

--- a/desktop/src/client/core/aad/authentication/authentication.service.ts
+++ b/desktop/src/client/core/aad/authentication/authentication.service.ts
@@ -290,7 +290,7 @@ export class AuthenticationService {
         const parsedUrl = new URL(url);
         const params = {};
         parsedUrl.searchParams.forEach((value: string, key: string) => {
-            params[key] = value
+            params[key] = value;
         });
         return params as any;
     }
@@ -310,7 +310,7 @@ export class AuthenticationService {
                     matches.length > 0 ? matches[0].displayName : tenantId
                 );
             }
-        )
+        );
     }
 }
 
@@ -371,7 +371,7 @@ class AuthorizeQueue {
         while (index < this.queue.length) {
             auth = this.queue[index];
             if (this.matches(auth, tenantId, resourceURI)) {
-                auth.deferred.reject(new LogoutError())
+                auth.deferred.reject(new LogoutError());
                 break;
             }
             index++;

--- a/desktop/src/client/core/aad/msal-cache-plugin.spec.ts
+++ b/desktop/src/client/core/aad/msal-cache-plugin.spec.ts
@@ -16,7 +16,7 @@ describe("MSALCachePlugin", () => {
             tokenCache: cacheSpy,
             cacheHasChanged: false
         };
-    })
+    });
     it("should get an item before the cache is called", async () => {
         expect(storeSpy.getItem).not.toHaveBeenCalled();
         await plugin.beforeCacheAccess(cacheContextSpy);

--- a/desktop/src/client/core/storage/storage-blob-adapter.spec.ts
+++ b/desktop/src/client/core/storage/storage-blob-adapter.spec.ts
@@ -143,7 +143,7 @@ function blobItem(name) {
             createdOn: null,
             lastModified: null
         }
-    }
+    };
 }
 
 function containerItem(name) {
@@ -196,10 +196,10 @@ function countGenerator<T>(count: number, pageContents: (num: number) => T) {
                 yield {
                     ...pageContents(size),
                     continuationToken: token
-                }
+                };
             }
         }
-    }
+    };
 }
 
 function blobItemGenerator(items: string[], flat = false) {
@@ -223,6 +223,6 @@ function blobItemGenerator(items: string[], flat = false) {
                 blobItems: blobs,
                 blobPrefixes: Object.values(prefixes)
             }
-        }
-    }
+        };
+    };
 }

--- a/desktop/src/client/core/storage/storage-blob-adapter.ts
+++ b/desktop/src/client/core/storage/storage-blob-adapter.ts
@@ -1,5 +1,11 @@
 import { Injectable } from "@angular/core";
-import { BlobHierarchyListSegment, BlobSASPermissions, BlobServiceClient, ContainerSASPermissions, StorageSharedKeyCredential } from "@azure/storage-blob";
+import {
+    BlobHierarchyListSegment,
+    BlobSASPermissions,
+    BlobServiceClient,
+    ContainerSASPermissions,
+    StorageSharedKeyCredential
+} from "@azure/storage-blob";
 import { autobind } from "@batch-flask/core";
 import { EncodingUtils } from "@batch-flask/utils";
 import * as blob from "app/services/storage/models/storage-blob";

--- a/desktop/src/test/utils/mocks/auth/auth-provider.mock.ts
+++ b/desktop/src/test/utils/mocks/auth/auth-provider.mock.ts
@@ -80,8 +80,8 @@ export const instrumentForAuth = app => {
     app.injector = {
         get: () => jasmine.createSpyObj("DataStore", ["getItem", "setItem"])
     };
-    app.properties = { azureEnvironment: AzurePublic }
-}
+    app.properties = { azureEnvironment: AzurePublic };
+};
 
 export const instrumentAuthProvider = (authProvider: AuthProvider) => {
     const tenants = {};
@@ -93,4 +93,4 @@ export const instrumentAuthProvider = (authProvider: AuthProvider) => {
             throw new Error("no account");
         }
     });
-}
+};

--- a/desktop/test/e2e/test-app-start.spec.ts
+++ b/desktop/test/e2e/test-app-start.spec.ts
@@ -60,7 +60,7 @@ async function signIn(app: ElectronApplication, authWindow: Page) {
     await authWindow.click(`input[type="submit"]`);
 
     // Wait until we see one of the valid next URLs
-    await authWindow.waitForURL(/(https:\/\/login\.microsoftonline\.com\/common\/oauth2\/v2\.0\/authorize|https:\/\/msft\.sts\.microsoft\.com)/)
+    await authWindow.waitForURL(/(https:\/\/login\.microsoftonline\.com\/common\/oauth2\/v2\.0\/authorize|https:\/\/msft\.sts\.microsoft\.com)/);
 
     // Click on "Sign with email or password instead"
     if (authWindow.url().startsWith("https://login.microsoftonline.com")) {

--- a/util/common-config/.eslintrc-common.json
+++ b/util/common-config/.eslintrc-common.json
@@ -43,6 +43,17 @@
         "checkLoops": false
       }
     ],
+    "no-restricted-globals": [
+      "error",
+      {
+        "name": "fdescribe",
+        "message": "Do not commit focused unit test suites"
+      },
+      {
+        "name": "fit",
+        "message": "Do not commit focused unit tests"
+      }
+    ],
     "no-restricted-imports": [
       "error",
       {


### PR DESCRIPTION
Overrides caused certain files from being ignored by ESLint. This PR places most of the rules into the desktop's rule set and ensures that it's used by all source code. Overrides define new rules, but still honor old rules. This PR also fixes a few dozen linting errors that were previously ignored (for example, missing semicolons from several unit test files).

Importantly, adds rules to disallow `fdescribe()` and `fit()`, so that we don't mistakenly merge focused tests.