### PR TITLE
Accessibility Fixes (332, 576, 592, 601, 598)

### DIFF
--- a/desktop/i18n/resources.resjson
+++ b/desktop/i18n/resources.resjson
@@ -149,6 +149,7 @@
   "gallery.recentTemplates": "Recent templates",
   "gallery.title": "Gallery applications",
   "gallery.viewReadme": "View readme",
+  "info-box.infoIconTitle": "Information",
   "job-progress-status.inaccurate": "Task count might not be accurate in real time",
   "job-progress-status.progressBar": "Job progress",
   "job-state.active.message": "Job is currently running. Task can be scheduled.",

--- a/desktop/src/@batch-flask/ui/info-box/info-box.component.ts
+++ b/desktop/src/@batch-flask/ui/info-box/info-box.component.ts
@@ -2,11 +2,7 @@ import { Component, Input } from "@angular/core";
 
 @Component({
     selector: "bl-info-box",
-    template: `
-        <div class="infobox">
-            <div class="infobox-image"><i class="fa fa-info-circle fa-3" aria-hidden="true"></i></div>
-            <div class="infobox-text">{{message}}</div>
-        </div>`,
+    templateUrl: "info-box.html",
 })
 export class InfoBoxComponent {
     @Input()

--- a/desktop/src/@batch-flask/ui/info-box/info-box.html
+++ b/desktop/src/@batch-flask/ui/info-box/info-box.html
@@ -1,0 +1,6 @@
+<div class="infobox">
+    <div class="infobox-image">
+        <i class="fa fa-info-circle fa-3" aria-hidden="true" title="{{'info-box.infoIconTitle' | i18n}}"></i>
+    </div>
+    <div class="infobox-text">{{message}}</div>
+</div>

--- a/desktop/src/@batch-flask/ui/info-box/info-box.i18n.yml
+++ b/desktop/src/@batch-flask/ui/info-box/info-box.i18n.yml
@@ -1,0 +1,2 @@
+info-box:
+  infoIconTitle: Information

--- a/desktop/src/@batch-flask/ui/info-box/info-box.module.ts
+++ b/desktop/src/@batch-flask/ui/info-box/info-box.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from "@angular/core";
 import { RouterModule } from "@angular/router";
 import { InfoBoxComponent } from "./info-box.component";
+import { I18nUIModule } from "../i18n";
 
 const components = [
     InfoBoxComponent,
@@ -10,7 +11,7 @@ const components = [
     declarations: components,
     entryComponents: [],
     exports: [...components],
-    imports: [RouterModule],
+    imports: [RouterModule, I18nUIModule],
 })
 
 export class InfoBoxModule {

--- a/desktop/src/@batch-flask/ui/list-and-show-layout/entity-details-list.html
+++ b/desktop/src/@batch-flask/ui/list-and-show-layout/entity-details-list.html
@@ -6,7 +6,8 @@
         <input blInput [formControl]="searchQuery" [placeholder]="filterPlaceholder + ' (Startwith)'"/>
         <bl-clickable *ngIf="enableAdvancedFilter"
             class="toggle-advanced-filter"
-            title="{{'entity-details-list.toggleAdvancedFilter' | i18n}}"
+            matTooltip="{{'entity-details-list.toggleAdvancedFilter' | i18n}}"
+            name="toggle"
             matTooltipPosition="above"
             [routerLink]="baseLink"
             [queryParams]="{filter: true}">

--- a/desktop/src/@batch-flask/ui/server-error/server-error.html
+++ b/desktop/src/@batch-flask/ui/server-error/server-error.html
@@ -10,6 +10,7 @@
                     [attr.aria-expanded]="showDebugInformation"
                     aria-controls="troubleshoot-debug-info"
                     role="button"
+                    name="troubleshoot"
                     title="{{'server-error.debug-button-label' | i18n}}"
                 >
                     <i class="fa fa-bug" aria-hidden="true"></i>

--- a/desktop/src/@batch-flask/ui/tags/tags.html
+++ b/desktop/src/@batch-flask/ui/tags/tags.html
@@ -1,6 +1,6 @@
 <div class="display" *ngIf="!isEditing && !saving" >
     <bl-tag-list [tags]="tags" [maxTags]="maxTags" [noTagsMessage]="noTagsMessage"></bl-tag-list>
-    <bl-clickable #editButton class="edit" matTooltip="Edit tags" (do)="edit()" *ngIf="editable">
+    <bl-clickable #editButton class="edit" matTooltip="Edit tags" name="edit" (do)="edit()" *ngIf="editable">
         <i class="fa fa-pencil" aria-hidden="true"></i>
     </bl-clickable>
 </div>

--- a/desktop/src/app/components/account/browse/account-list/account-list.scss
+++ b/desktop/src/app/components/account/browse/account-list/account-list.scss
@@ -11,6 +11,10 @@ bl-account-list {
         .fa-star.favorite {
             text-shadow: -1px 0 $main-background, 0 1px $main-background, 1px 0 $main-background, 0 -1px $main-background;
         }
+
+        .auto-storage.error {
+            color: $danger-contrast-color;
+        }
     }
 
     .fa-star {
@@ -42,11 +46,11 @@ bl-account-list {
 
         .auto-storage {
             margin-right: 7px;
+        }
 
-            &.error {
-                color: $danger-color;
-                font-weight: bold;
-            }
+        .auto-storage.error {
+            color: $danger-color;
+            font-weight: bold;
         }
     }
 }

--- a/desktop/src/app/components/job/base/job-state/job-state.scss
+++ b/desktop/src/app/components/job/base/job-state/job-state.scss
@@ -18,6 +18,10 @@ bl-job-state {
 
             .fa-play-circle {
                 color: $primary-color;
+
+                [aria-selected=true] & {
+                    color: $primary-contrast-color;
+                }
             }
 
             .fa-trash {

--- a/desktop/src/app/components/pool/base/pool-nodes-preview.scss
+++ b/desktop/src/app/components/pool/base/pool-nodes-preview.scss
@@ -13,9 +13,17 @@ bl-pool-nodes-preview {
     &.resize-error {
         color: $danger-color;
         font-weight: bold;
+
+        [aria-selected=true] & {
+            color: $danger-contrast-color;
+        }
     }
 
     .fa {
         margin-right: 2px;
+    }
+
+    [aria-selected=true] & {
+        color: $primary-contrast-color;
     }
 }

--- a/desktop/src/app/components/pool/graphs/heatmap/nodes-heatmap.component.spec.ts
+++ b/desktop/src/app/components/pool/graphs/heatmap/nodes-heatmap.component.spec.ts
@@ -131,7 +131,7 @@ describe("NodesHeatmapComponent", () => {
             expect(bg.selectAll("rect").size()).toBe(1, "Should only have 1 rect");
             const rect = bg.select("rect");
             expect(rect).not.toBeFalsy("Should have a rect in bg");
-            expect(rect.attr("style")).toContain("fill: rgb(237, 238, 242);");
+            expect(rect.attr("style")).toContain("fill: rgb(145, 145, 145);");
             expect(rect.attr("style")).toContain("stroke-width: 0;");
         });
     });

--- a/desktop/src/app/components/pool/graphs/heatmap/nodes-heatmap.component.ts
+++ b/desktop/src/app/components/pool/graphs/heatmap/nodes-heatmap.component.ts
@@ -25,7 +25,7 @@ interface HeatmapTile {
 
 type NodeSelection = Selection<SVGGElement, HeatmapTile, BaseType, unknown>;
 
-const idleColor = "#edeef2";
+const idleColor = "#919191";
 const runningColor = "#178D17";
 
 const stateTree: StateTree = [
@@ -49,7 +49,7 @@ const stateTree: StateTree = [
     },
     { state: NodeState.waitingForStartTask, color: "#be93d9" },
     { state: NodeState.offline, color: "#305796" },
-    { state: NodeState.preempted, color: "#606060" },
+    { state: NodeState.preempted, color: "#313131" },
     {
         category: "transition",
         label: "Transition states",

--- a/desktop/src/app/components/pool/graphs/pool-state-graph/pool-state-graph.component.ts
+++ b/desktop/src/app/components/pool/graphs/pool-state-graph/pool-state-graph.component.ts
@@ -15,11 +15,11 @@ import { Subscription } from "rxjs";
 
 import "./pool-state-graph.scss";
 
-const idleColor = "#edeef2";
+const idleColor = "#919191";
 const runningColor = "#328000";
 const waitingForStartTaskColor = "#be93d9";
 const offlineColor = "#305796";
-const preemptedColor = "#606060";
+const preemptedColor = "#313131";
 const transitionColor = "#ffcc5c";
 const errorColor = "#aa3939";
 


### PR DESCRIPTION
This PR Fixes:

- [Bug 332] [Visual Requirement-Batch explorer-Pools] Luminosity contrast ratio of the focusable element is less than 3:1 i.e 1.2:1.
- [Bug 576] [Programmatic Access-Batch Explorer-Edit] On the Update the storage account blade, name and aria-expanded property are not defined for the expand and collapse button.
- [Bug 592] [Programmatic Access-Batch Explorer-Pools-Edit tags] On the pools blade, the name is not defined for the edit tags button.
- [Bug 601] [Programmatic Access-Batch Explorer-Pool-Nodes] The name is not defined for the toggle advanced filter button.
- [Bug 598] [Screen Reader-Batch Explorer-Jobs-Disable] ALT is not defined for the image available on the "Are you sure you want to disable job" dialog box.

I also [updated the colors](https://github.com/Azure/BatchExplorer/pull/2738/commits/846050792bdd9286e97e8bbda9e511850716859d) of elements in the sidebar selected item for better contrast ratios:

|Before|After|
|---|---|
|  <img width="376" alt="Screenshot 2023-06-01 at 1 58 13 PM" src="https://github.com/Azure/BatchExplorer/assets/79171711/9d483d3d-945e-4187-a852-bd45e6e43e72"> |  <img width="376" alt="Screenshot 2023-06-01 at 1 53 45 PM" src="https://github.com/Azure/BatchExplorer/assets/79171711/8a08414b-517a-47a4-87b6-46f0c4d61855">  |
| <img width="373" alt="Screenshot 2023-06-01 at 1 58 04 PM" src="https://github.com/Azure/BatchExplorer/assets/79171711/554fffd6-66e8-4618-889c-fd9101800233"> | <img width="361" alt="Screenshot 2023-06-01 at 1 56 52 PM" src="https://github.com/Azure/BatchExplorer/assets/79171711/8ae3c553-df7c-4bbf-b837-06a42a8845f3"> |