### PR TITLE
Switch packages to v1.0.1 and publish from main branch only

### DIFF
--- a/.vsts/common/publish-packages.sh
+++ b/.vsts/common/publish-packages.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+package_name=$1
+if [ -z $package_name ]; then
+    echo "Failed to publish package: No package name supplied"
+    exit 1
+fi
+
+ver=$(npm pkg get version | sed 's/"//g')
+package_version=$(echo "$ver-$DIST_TAG.$BUILD_BUILDNUMBER" | sed 's/_//g')
+
+# Publish only from the main branch for now so that we don't have to worry
+# about version bumping after releases from different branches.
+if [ $(git symbolic-ref -q --short HEAD) = 'main' ]; then
+    echo "Publishing package $package_name@$package_version"
+
+    npm version --no-git-tag-version $package_version
+    npm publish --tag $DIST_TAG
+else
+    echo "Skipped publishing $package_name@$package_version: Packages are only published from the main branch."
+fi

--- a/.vsts/linux/publish-npm-package.yml
+++ b/.vsts/linux/publish-npm-package.yml
@@ -3,12 +3,6 @@ parameters:
   packageName: ''
 
 steps:
-  - bash: |
-      set -e
-      ver=$(npm pkg get version | sed 's/"//g')
-      package_version=$(echo "$ver-$DIST_TAG.$BUILD_BUILDNUMBER" | sed 's/_//g')
-      echo "Publishing package ${{parameters.packageName}}@$package_version"
-      npm version --no-git-tag-version $package_version
-      npm publish --tag $DIST_TAG
-    displayName: "Publish package: ${{parameters.packageName}}"
-    workingDirectory: ${{parameters.packagePath}}
+    - bash: $(Build.SourcesDirectory)/.vsts/common/publish-packages.sh ${{parameters.packageName}}
+      displayName: "Publish package: ${{parameters.packageName}}"
+      workingDirectory: ${{parameters.packagePath}}

--- a/packages/arm-batch-rest/package-lock.json
+++ b/packages/arm-batch-rest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@batch/arm-batch-rest",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@batch/arm-batch-rest",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@azure-rest/core-client": "1.0.0-beta.10",

--- a/packages/arm-batch-rest/package.json
+++ b/packages/arm-batch-rest/package.json
@@ -2,7 +2,7 @@
   "name": "@batch/arm-batch-rest",
   "sdk-type": "mgmt",
   "author": "Microsoft Corporation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A generated Rest Level Client SDK for the Batch Management Plane.",
   "keywords": [
     "node",

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@batch/ui-common",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@batch/ui-common",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.14.168",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@batch/ui-common",
   "private": false,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Common library for Azure Batch user interfaces",
   "repository": {
     "type": "git",

--- a/packages/playground/package-lock.json
+++ b/packages/playground/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@batch/ui-playground",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@batch/ui-playground",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^8.0.0",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@batch/ui-playground",
   "private": false,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Playground for Azure Batch Shared Component Library",
   "repository": {
     "type": "git",

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@batch/ui-react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@batch/ui-react",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/dom": "^8.0.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@batch/ui-react",
   "private": false,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Azure Batch shared React component library",
   "repository": {
     "type": "git",

--- a/packages/service/package-lock.json
+++ b/packages/service/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@batch/ui-service",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@batch/ui-service",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^27.0.1",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@batch/ui-service",
   "private": false,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Library for communicating with the Azure Batch service",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is to address a problem with consuming multiple pre-release versions from the same package feed.