### PR TITLE
Fix package publishing script

### DIFF
--- a/.vsts/common/publish-packages.sh
+++ b/.vsts/common/publish-packages.sh
@@ -2,7 +2,13 @@
 
 set -e
 
-package_name=$1
+branch=$1
+if [ -z $1 ]; then
+    echo "Failed to publish package: No branch name supplied"
+    exit 1
+fi
+
+package_name=$2
 if [ -z $package_name ]; then
     echo "Failed to publish package: No package name supplied"
     exit 1
@@ -11,11 +17,15 @@ fi
 ver=$(npm pkg get version | sed 's/"//g')
 package_version=$(echo "$ver-$DIST_TAG.$BUILD_BUILDNUMBER" | sed 's/_//g')
 
+echo "Publishing package $package_name@$package_version"
+echo "=================================="
+echo "Working dir: $PWD"
+echo "Branch: $branch"
+echo "=================================="
+
 # Publish only from the main branch for now so that we don't have to worry
 # about version bumping after releases from different branches.
-if [ $(git symbolic-ref -q --short HEAD) = 'main' ]; then
-    echo "Publishing package $package_name@$package_version"
-
+if [ "$branch" = "refs/heads/main" ]; then
     npm version --no-git-tag-version $package_version
     npm publish --tag $DIST_TAG
 else

--- a/.vsts/linux/publish-npm-package.yml
+++ b/.vsts/linux/publish-npm-package.yml
@@ -3,6 +3,8 @@ parameters:
   packageName: ''
 
 steps:
-    - bash: $(Build.SourcesDirectory)/.vsts/common/publish-packages.sh ${{parameters.packageName}}
+    - script: |
+        set -e
+        $(Build.SourcesDirectory)/.vsts/common/publish-packages.sh $(Build.SourceBranch) ${{parameters.packageName}}
       displayName: "Publish package: ${{parameters.packageName}}"
       workingDirectory: ${{parameters.packagePath}}


### PR DESCRIPTION
This was broken because the Git repo on the DevOps pipelines runs on a detached HEAD. Use the DevOps environment variable to read the target branch instead of using `git symbolic-ref`.