### PR TITLE
Bump MacOS dist pipeline timeout to 2 hour

### DIFF
--- a/.vsts/distribution.yml
+++ b/.vsts/distribution.yml
@@ -35,6 +35,7 @@ stages:
           - template: ./linux/distribution.yml
 
       - job: MacOS
+        timeoutInMinutes: 120  # Needed because Codesign and Notarization add 20+ minutes
         pool:
           vmImage: macOS-11
           demands: xcode


### PR DESCRIPTION
Notarization and code signing are making the MacOS distribution come extremely close (or over) the 60 minute default timeout.