### PR TITLE
Add Indonesian translations and fix Portuguese locale code in desktop app

### DIFF
--- a/desktop/src/@batch-flask/core/i18n/locale.service.ts
+++ b/desktop/src/@batch-flask/core/i18n/locale.service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable security/detect-bidi-characters */
 import { Injectable } from "@angular/core";
 
 export enum Locale {
@@ -7,13 +8,14 @@ export enum Locale {
     Spanish = "es",
     French = "fr",
     Hungarian = "hu",
+    Indonesian = "id",
     Italian = "it",
     Japanese = "ja",
     Korean = "ko",
     Dutch = "nl",
     Polish = "pl",
     BrazilianPortuguese = "pt-BR",
-    Portuguese = "pt",
+    Portuguese = "pt-PT",
     Russian = "ru",
     Swedish = "sv",
     Turkish = "tr",
@@ -29,6 +31,7 @@ export const TranslatedLocales = {
     [Locale.Spanish]: "Español‎",
     [Locale.French]: "Français‎",
     [Locale.Hungarian]: "Magyar‎",
+    [Locale.Indonesian]: "Indonesia",
     [Locale.Italian]: "Italiano",
     [Locale.Japanese]: "日本語‎",
     [Locale.Korean]: "한국어‎",


### PR DESCRIPTION
- Fix the locale code for Portuguese in the desktop app so that the Portuguese translations render correctly 
- Add Indonesian to list of supported languages in the desktop app
  - Checked multiple translation services and Edge/Google Chrome language settings, and it seems that the standard way to write the word ‘Indonesian’ in the Indonesian language for digital localization purposes is simply ‘Indonesia’ 
- Disable security warning for non-English characters for locale file