### PR TITLE
Build pipeline perf improvements

### DIFF
--- a/.vsts/common/setup-python.sh
+++ b/.vsts/common/setup-python.sh
@@ -3,32 +3,7 @@
 set -e
 
 pyroot="$AGENT_WORKFOLDER/.venv/batchexplorer"
-
-if [ "$AGENT_OS" == "Windows_NT" ]; then
-    # Python is already installed via a pipeline task
-    conf_file="$pyroot/pip.ini"
-else
-    conf_file="$pyroot/pip.conf"
-    pyenv_version=2.3.2
-    python_version=3.9.4
-
-    echo "Installing pyenv..."
-    export PYENV_ROOT="$AGENT_WORKFOLDER/.pyenv"
-    archive="$PYENV_ROOT/pyenv.tar.gz"
-    mkdir -p "$PYENV_ROOT"
-    curl -s -S -L "https://github.com/pyenv/pyenv/archive/v${pyenv_version}.tar.gz" > "$archive"
-    echo "f4347e6740e6cd47badc302491b105615a74fbf2  $archive" | shasum -c
-    tar xzf "$archive" -C "$PYENV_ROOT" --strip-components=1
-    export PATH="$PYENV_ROOT/bin:$PATH"
-    pyenv --version
-
-    echo "Installing Python $python_version..."
-    env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install $python_version
-    pyenv global "$python_version"
-    eval "$(pyenv init -)"
-    echo "##vso[task.prependpath]$PYENV_ROOT/bin"
-    echo "##vso[task.prependpath]$PYENV_ROOT/shims"
-fi
+conf_file="$pyroot/pip.ini"
 
 echo "Setting up Python virtual environment..."
 python -m venv "$pyroot"

--- a/.vsts/darwin/darwin-dependencies.yml
+++ b/.vsts/darwin/darwin-dependencies.yml
@@ -2,17 +2,9 @@ steps:
   - template: ../dependencies.yml
   - script: |
       set -e
-      echo "Homebrew version $(brew --version)"
-      brew install openssl readline sqlite3 xz zlib tcl-tk
-    displayName: Install MacOS Python dependencies
-  - script: |
-      set -e
       echo "Node.js version $(node --version)"
       echo "NPM version $(npm --version)"
       npm ci
+      npm run dev-setup
     displayName: Install MacOS JavaScript dependencies
-  - script: |
-      cd util/bux
-      npm pack
-      npm install -g batch-bux-1.0.0.tgz
-    displayName: Install Batch Utility CLI (bux)
+

--- a/.vsts/linux/linux-dependencies.yml
+++ b/.vsts/linux/linux-dependencies.yml
@@ -1,12 +1,4 @@
 steps:
-  - script: |
-      set -e
-      sudo apt-get update
-      echo "Installing pyenv dependencies (see https://github.com/pyenv/pyenv/wiki/Common-build-problems#prerequisites)"
-      sudo apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git
-      echo "Installing additional dependencies"
-      sudo apt-get install -y libxkbfile-dev pkg-config libsecret-1-dev libxss1 libgconf-2-4 dbus xvfb libgtk-3-0 rpm
-    displayName: Install Linux packages
   - template: ../dependencies.yml
   - script: |
       set -e
@@ -14,9 +6,5 @@ steps:
       echo "NPM version $(npm --version)"
       npm install -g codecov
       npm ci
+      npm run dev-setup
     displayName: Install NPM dependencies
-  - script: |
-      cd util/bux
-      npm pack
-      npm install -g batch-bux-1.0.0.tgz
-    displayName: Install Batch Utility CLI (bux)

--- a/.vsts/python-setup.yml
+++ b/.vsts/python-setup.yml
@@ -1,9 +1,8 @@
 steps:
   - task: UsePythonVersion@0
-    condition: eq( variables['Agent.OS'], 'Windows_NT' )
     inputs:
-      versionSpec: '3.9'
-    displayName: Install Python 3.9 for Batch Explorer
+      versionSpec: '3.10'
+    displayName: Use Python 3.10
 
   - bash: ./.vsts/common/setup-python.sh
     displayName: Set up Python environment and private feed

--- a/.vsts/win/win-dependencies.yml
+++ b/.vsts/win/win-dependencies.yml
@@ -6,11 +6,5 @@ steps:
       exec { Write-Host "Node.js version" $(node --version) }
       exec { Write-Host "NPM version" $(npm --version) }
       exec { npm ci }
+      exec { npm run dev-setup }
     displayName: Install Windows dependencies
-  - powershell: |
-      . ../../.vsts/win/exec.ps1
-      $ErrorActionPreference = "Stop"
-      exec { npm pack }
-      exec { npm install -g batch-bux-1.0.0.tgz }
-    workingDirectory: util/bux
-    displayName: Install Batch Utility CLI (bux)


### PR DESCRIPTION
Use pre-installed dependencies on MS images where possible instead of installing them at build-time. Also switch the `bux` install to use the `dev-setup` NPM script.