### PR TITLE
Move typed emitter from dev dependenciess to dependencies

### DIFF
--- a/packages/bonito-core/package-lock.json
+++ b/packages/bonito-core/package-lock.json
@@ -13,15 +13,15 @@
         "@types/luxon": "^2.0.2",
         "events": "^3.3.0",
         "lodash": "^4.17.20",
-        "luxon": "^2.5.2"
+        "luxon": "^2.5.2",
+        "typed-emitter": "^2.1.0"
       },
       "devDependencies": {
         "@types/jest": "^27.0.1",
         "@types/node": "20.5.4",
         "jest": "^27.1.0",
         "jest-junit": "^12.2.0",
-        "ts-jest": "^27.0.5",
-        "typed-emitter": "^2.1.0"
+        "ts-jest": "^27.0.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3630,7 +3630,6 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -4024,7 +4023,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true,
       "optional": true
     },
     "node_modules/type-detect": {
@@ -4052,7 +4050,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
       "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
-      "dev": true,
       "optionalDependencies": {
         "rxjs": "*"
       }

--- a/packages/bonito-core/package.json
+++ b/packages/bonito-core/package.json
@@ -63,7 +63,8 @@
     "@types/luxon": "^2.0.2",
     "events": "^3.3.0",
     "lodash": "^4.17.20",
-    "luxon": "^2.5.2"
+    "luxon": "^2.5.2",
+    "typed-emitter": "^2.1.0"
   },
   "devDependencies": {
     "@batch/common-config": "^1.0.0",
@@ -71,8 +72,7 @@
     "@types/node": "20.5.4",
     "jest": "^27.1.0",
     "jest-junit": "^12.2.0",
-    "ts-jest": "^27.0.5",
-    "typed-emitter": "^2.1.0"
+    "ts-jest": "^27.0.5"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Move 'typed emitter' in bonito-core `package.json` from `dev-dependencies` to `dependencies` to resolve an error