### PR TITLE
Minor MockHttpClient improvements

### DIFF
--- a/packages/bonito-core/src/http/__tests__/mock-http-client.spec.ts
+++ b/packages/bonito-core/src/http/__tests__/mock-http-client.spec.ts
@@ -222,4 +222,45 @@ describe("MockHttpClient", () => {
             await (await client.put("/some/url", { body: "two" })).text()
         ).toBe("response two");
     });
+
+    test("supports sending string bodies", async () => {
+        const client = new MockHttpClient();
+        client.addExpected(
+            new MockHttpResponse("/some/url", {
+                status: 200,
+            }),
+            {
+                method: "PUT",
+                body: "this is a string",
+            }
+        );
+        const response = await client.put("/some/url", {
+            body: "this is a string",
+        });
+        expect(response.status).toBe(200);
+    });
+
+    test("supports sending URLSearchParams bodies", async () => {
+        const client = new MockHttpClient();
+
+        const body = new URLSearchParams({
+            color: "red",
+            shape: "triangle",
+        });
+        expect(client.serializeBody(body)).toBe("color=red&shape=triangle");
+
+        client.addExpected(
+            new MockHttpResponse("/some/url", {
+                status: 200,
+            }),
+            {
+                method: "PUT",
+                body,
+            }
+        );
+        const response = await client.put("/some/url", {
+            body,
+        });
+        expect(response.status).toBe(200);
+    });
 });

--- a/packages/bonito-core/src/http/__tests__/mock-http-client.spec.ts
+++ b/packages/bonito-core/src/http/__tests__/mock-http-client.spec.ts
@@ -106,6 +106,25 @@ describe("MockHttpClient", () => {
         );
     });
 
+    test("response URL and request URL can be different", async () => {
+        const client = new MockHttpClient();
+
+        client.addExpected(
+            new MockHttpResponse("https://contoso.net/foobar", {
+                status: 200,
+                body: "foobaz",
+            }),
+            {
+                method: "GET",
+                url: "/foobar",
+            }
+        );
+
+        const response = await client.fetch("/foobar");
+        expect(response.url).toBe("https://contoso.net/foobar");
+        expect(await response.text()).toBe("foobaz");
+    });
+
     test("can mock all methods", async () => {
         const client = new MockHttpClient();
 

--- a/packages/bonito-core/src/http/mock-http-client.ts
+++ b/packages/bonito-core/src/http/mock-http-client.ts
@@ -85,7 +85,11 @@ export class MockHttpClient extends AbstractHttpClient {
         response: MockHttpResponse,
         requestProps: HttpRequestInit = {}
     ): MockHttpClient {
-        const key = this._getKeyFromRequest(response.url, requestProps, true);
+        const key = this._getKeyFromRequest(
+            requestProps.url ?? response.url,
+            requestProps,
+            true
+        );
         const expected = this._expectedResponses[key] ?? [];
         expected.push(response);
         this._expectedResponses[key] = expected;


### PR DESCRIPTION
Added support for mocking UrlSearchParams bodies and fixed a minor issue where request URLs were ignored when setting expected requests.