### PR TITLE
Accessibility fixes for color contrast, link colors

### DIFF
--- a/desktop/src/@batch-flask/ui/notifications/toast/toast.scss
+++ b/desktop/src/@batch-flask/ui/notifications/toast/toast.scss
@@ -41,6 +41,22 @@ bl-toast {
         background-color: $warn-color;
     }
 
+    &.success > .focus-outline.focus-visible {
+        outline-color: $success-contrast-color;
+    }
+
+    &.error > .focus-outline.focus-visible {
+        outline-color: $danger-contrast-color;
+    }
+
+    &.info > .focus-outline.focus-visible {
+        outline-color: $primary-contrast-color;
+    }
+
+    &.warn > .focus-outline.focus-visible {
+        outline-color: $warn-contrast-color;
+    }
+
     &.notification-hidden {
         opacity: 0;
     }
@@ -58,6 +74,7 @@ bl-toast {
 
     > .dismiss-btn {
         cursor: pointer;
+        padding: 2px;
         .fa-times {
             color: $primary-contrast-color;
         }

--- a/desktop/src/@batch-flask/ui/quick-list/quick-list-row-render/quick-list-row-render.scss
+++ b/desktop/src/@batch-flask/ui/quick-list/quick-list-row-render/quick-list-row-render.scss
@@ -73,7 +73,7 @@ bl-quick-list-row-render {
         padding: 5px;
 
         i {
-            padding-left: 4px;
+            padding: 2px;
         }
 
         .fa-hourglass-half {
@@ -123,7 +123,6 @@ bl-quick-list-row-render {
     .quick-list-details {
         flex: 1 1 auto;
         overflow: hidden;
-        padding: 3px;
         text-overflow: ellipsis;
         min-width: 0;
 
@@ -143,6 +142,10 @@ bl-quick-list-row-render {
             right: 0;
 
         }
+    }
+
+    .focus-outline.focus-visible {
+        outline-color: $card-background;
     }
 }
 

--- a/desktop/src/@batch-flask/ui/summary-card/summary-card.scss
+++ b/desktop/src/@batch-flask/ui/summary-card/summary-card.scss
@@ -29,6 +29,10 @@ bl-summary-card {
 
                 > .details {
                     color: $secondary-text;
+
+                    bl-clickable {
+                        color: $primary-color;
+                    }
                 }
             }
         }

--- a/desktop/src/app/styles/vendor/material-theme.scss
+++ b/desktop/src/app/styles/vendor/material-theme.scss
@@ -197,6 +197,10 @@ mat-button-toggle-group {
     }
 }
 
+mat-calendar .mat-calendar-table-header {
+    color: rgba(0, 0, 0, 0.87);
+}
+
 .cdk-high-contrast-active .mat-drawer.mat-drawer-end {
     border-left: none;
 }


### PR DESCRIPTION
## Screenshots:

Notification close button focus outline color contrast:
<img width="393" alt="1137-fix" src="https://github.com/Azure/BatchExplorer/assets/509299/17780f76-7cb3-43e4-8b01-684997ac2ee2">

-----------------

Calendar weekday text color contrast:
<img width="284" alt="Screenshot 2023-10-19 at 9 56 59 AM" src="https://github.com/Azure/BatchExplorer/assets/509299/5e2e36f4-8179-4519-a765-f5d08fb1fc48">

-----------------

Star icon focus outline color contrast:
<img width="350" alt="Screenshot 2023-10-19 at 10 10 52 AM" src="https://github.com/Azure/BatchExplorer/assets/509299/6da73aa4-83eb-4999-9422-b1b818909870">

-----------------

Subscription & resource group link colors (used to be regular text color):
<img width="290" alt="Screenshot 2023-10-19 at 10 21 36 AM" src="https://github.com/Azure/BatchExplorer/assets/509299/93cb6480-95c2-476b-8175-e60b886250f4">

-----------------

Also includes a very minor alignment fix on lists to vertically center the text.

Before:
<img width="353" alt="Screenshot 2023-10-19 at 10 37 37 AM" src="https://github.com/Azure/BatchExplorer/assets/509299/f5ff45dd-5497-4b70-9668-3894f9894f48">

After:
<img width="351" alt="Screenshot 2023-10-19 at 10 37 51 AM" src="https://github.com/Azure/BatchExplorer/assets/509299/08e5d1b3-f9c0-4a71-973f-b72874c2762d">
