### PR TITLE
Make CryptoService tests use a more obviously fake key for tests

### DIFF
--- a/desktop/src/client/core/secure-data-store/crypto-service.spec.ts
+++ b/desktop/src/client/core/secure-data-store/crypto-service.spec.ts
@@ -7,7 +7,8 @@ describe("CryptoService", () => {
     let masterKey: string | null = null;
 
     beforeEach(() => {
-        masterKey = "fbea88f2f4efeb0640cb411aa7df41cb";
+        // Fake testing key needs to be 32 characters long
+        masterKey = "------fake-key-for-testing------";
         keytarSpy = {
             setPassword: jasmine.createSpy("setPassword").and.callFake((x) => {
                 masterKey = x;


### PR DESCRIPTION
The current value looks too much like a real secret. Switched to a more obviously fake string.