### PR TITLE
Add optional base URL path to environment

### DIFF
--- a/packages/bonito-core/src/environment/abstract-environment.ts
+++ b/packages/bonito-core/src/environment/abstract-environment.ts
@@ -13,6 +13,8 @@ import {
 import { Clock } from "../datetime/clock";
 import { Notifier } from "../notification";
 
+const DEFAULT_BASE_PATH = "/";
+
 /**
  * Abstract base class for shared functionality across different environments
  */
@@ -31,6 +33,13 @@ export abstract class AbstractEnvironment<
     }
 
     private _diContainer: DiContainer<D>;
+
+    /**
+     * Get the globally configured base path, or "/" if none is defined.
+     */
+    getBasePath(): string {
+        return this.config.basePath ?? DEFAULT_BASE_PATH;
+    }
 
     /**
      * Get the currently configured clock

--- a/packages/bonito-core/src/environment/environment.ts
+++ b/packages/bonito-core/src/environment/environment.ts
@@ -32,6 +32,11 @@ export interface Environment<C extends EnvironmentConfig> {
     readonly initialized: boolean;
 
     /**
+     * Get the global base URI path
+     */
+    getBasePath(): string;
+
+    /**
      * Gets the currently configured clock
      */
     getClock(): Clock;
@@ -135,6 +140,11 @@ export interface EnvironmentConfig {
      * cloud environment.
      */
     armUrl: string;
+
+    /**
+     * The base path applied to all relative URIs
+     */
+    basePath?: string;
 
     /**
      * Environment variables when running in a Node.js process

--- a/packages/bonito-core/src/http/__tests__/mock-http-client.spec.ts
+++ b/packages/bonito-core/src/http/__tests__/mock-http-client.spec.ts
@@ -1,3 +1,4 @@
+import { getEnvironment, initMockEnvironment } from "../../environment";
 import { MockHttpClient, MockHttpResponse } from "../mock-http-client";
 
 const mockResponses = {
@@ -17,9 +18,19 @@ const mockResponses = {
                 "Content-Type": "application/json",
             },
         }),
+    savannah: () =>
+        new MockHttpResponse("/a/b/c/dogs/savannah", {
+            status: 200,
+            body: `{"name": "Savannah", "breed": "Husky"}`,
+            headers: {
+                "Content-Type": "application/json",
+            },
+        }),
 };
 
 describe("MockHttpClient", () => {
+    beforeEach(() => initMockEnvironment());
+
     test("can Mock a single GET request", async () => {
         const client = new MockHttpClient();
         client.addExpected(mockResponses.parker());
@@ -27,6 +38,18 @@ describe("MockHttpClient", () => {
         const response = await client.get("/dogs/parker");
         expect(await response.text()).toBe(
             `{"name": "Parker", "breed": "Schnauzer"}`
+        );
+    });
+
+    test("can use a non-default base path", async () => {
+        const client = new MockHttpClient();
+        client.addExpected(mockResponses.savannah());
+
+        getEnvironment().config.basePath = "/a/b/c";
+
+        const response = await client.get("/dogs/savannah");
+        expect(await response.text()).toBe(
+            `{"name": "Savannah", "breed": "Husky"}`
         );
     });
 

--- a/packages/bonito-core/src/http/fetch-http-client.ts
+++ b/packages/bonito-core/src/http/fetch-http-client.ts
@@ -1,3 +1,4 @@
+import { normalizeUrl } from "../util/url";
 import { CustomHttpHeaders } from "./constants";
 import { AbstractHttpClient, HttpRequestInit } from "./http-client";
 
@@ -28,6 +29,7 @@ export class FetchHttpClient extends AbstractHttpClient {
             }
             url = req.url;
         }
+        url = normalizeUrl(url);
 
         let responsePromise: Promise<Response>;
         if (!req) {

--- a/packages/bonito-core/src/http/mock-http-client.ts
+++ b/packages/bonito-core/src/http/mock-http-client.ts
@@ -1,3 +1,4 @@
+import { normalizeUrl } from "../util/url";
 import { HttpRequestMethod } from "./constants";
 import {
     AbstractHttpClient,
@@ -34,6 +35,7 @@ export class MockHttpClient extends AbstractHttpClient {
             }
             url = urlOrRequest.url;
         }
+        url = normalizeUrl(url);
 
         const key = this._getKeyFromRequest(url, props);
         const expected = this._expectedResponses[key];

--- a/packages/bonito-core/src/index.ts
+++ b/packages/bonito-core/src/index.ts
@@ -43,8 +43,10 @@ export {
     debounce,
     DebouncedFunction,
     delay,
+    getNormalizedBasePath,
     isPromiseLike,
     mergeDeep,
+    normalizeUrl,
     startsWithIgnoreCase,
     uniqueId,
 } from "./util";

--- a/packages/bonito-core/src/util/__tests__/url.spec.ts
+++ b/packages/bonito-core/src/util/__tests__/url.spec.ts
@@ -1,0 +1,33 @@
+import { getEnvironment, initMockEnvironment } from "../../environment";
+import { getNormalizedBasePath, normalizeUrl } from "../url";
+
+describe("URL utility functions", () => {
+    beforeEach(() => initMockEnvironment());
+
+    test("getNormalizedBasePath() function", () => {
+        expect(getNormalizedBasePath()).toEqual("/");
+        getEnvironment().config.basePath = "a/";
+        expect(getNormalizedBasePath()).toEqual("/a/");
+        getEnvironment().config.basePath = "/a/b";
+        expect(getNormalizedBasePath()).toEqual("/a/b/");
+    });
+
+    test("normalizeUrl() function", () => {
+        // Relative URLs include leading slashes
+        expect(normalizeUrl("a")).toEqual("/a");
+        getEnvironment().config.basePath = "a/b";
+        expect(normalizeUrl("hello")).toEqual("/a/b/hello");
+        expect(normalizeUrl("/hello")).toEqual("/a/b/hello");
+        expect(normalizeUrl("/hello?param1=value1&param2=value2")).toEqual(
+            "/a/b/hello?param1=value1&param2=value2"
+        );
+
+        // External URLs are left untouched
+        expect(normalizeUrl("https://contoso.net/a/b/c")).toEqual(
+            "https://contoso.net/a/b/c"
+        );
+        expect(normalizeUrl("http://contoso.net/a/b/c")).toEqual(
+            "http://contoso.net/a/b/c"
+        );
+    });
+});

--- a/packages/bonito-core/src/util/index.ts
+++ b/packages/bonito-core/src/util/index.ts
@@ -3,3 +3,4 @@ export * from "./ordered-map";
 export * from "./string";
 export * from "./deferred";
 export * from "./cancellable-promise";
+export * from "./url";

--- a/packages/bonito-core/src/util/url.ts
+++ b/packages/bonito-core/src/util/url.ts
@@ -1,0 +1,40 @@
+import { getEnvironment } from "../environment";
+
+/**
+ * Get the globally configured base path, normalized to always include both
+ * leading and trailing forward slashes.
+ *
+ * For example, if the basePath config property is "foo", this function will
+ * return "/foo/".
+ */
+export function getNormalizedBasePath(): string {
+    let basePath = getEnvironment().getBasePath();
+    if (!basePath.endsWith("/")) {
+        basePath = basePath + "/";
+    }
+    if (!basePath.startsWith("/")) {
+        basePath = "/" + basePath;
+    }
+    return basePath;
+}
+
+/**
+ * Returns a normalized URL which is either absolute, or if relative
+ * always includes a leading slash and any configured base path.
+ *
+ * @param url A relative or absolute URL string
+ * @returns A normalized URL string
+ */
+export function normalizeUrl(url: string): string {
+    if (!url || typeof url !== "string") {
+        throw new Error("Cannot normalize invalid URL: " + url);
+    }
+
+    if (url.indexOf("http") === 0) {
+        // Absolute URLs are left untouched
+        return url;
+    }
+
+    const relPath = url.charAt(0) === "/" ? url.substring(1) : url;
+    return getNormalizedBasePath() + relPath;
+}


### PR DESCRIPTION
When using bonito in an environment with a base path (ie: pages that define a `<base>` tag), automatically normalize calls through HttpClient to include the base path if it is defined.