### PR TITLE
Build scripts call python3/pip3 instead of python/pip

### DIFF
--- a/.vsts/common/setup-python.sh
+++ b/.vsts/common/setup-python.sh
@@ -6,7 +6,7 @@ pyroot="$AGENT_WORKFOLDER/.venv/batchexplorer"
 conf_file="$pyroot/pip.ini"
 
 echo "Setting up Python virtual environment..."
-python -m venv "$pyroot"
+python3 -m venv "$pyroot"
 if [ "$AGENT_OS" == "Windows_NT" ]; then
     "$pyroot/Scripts/activate"
 else
@@ -15,12 +15,12 @@ fi
 echo "Path is $PATH"
 
 echo "Upgrading pip..."
-python -m pip install --upgrade pip
-pip install keyring artifacts-keyring
+python3 -m pip install --upgrade pip
+pip3 install keyring artifacts-keyring
 
 echo "Configuring private feed..."
 # If the target conf file doesn't exist, pip config creates one at the user dir.
 # This doesn't matter all that much for build agents.
 touch "$conf_file"
-pip config set global.index-url https://azurebatch.pkgs.visualstudio.com/_packaging/BatchExplorer/pypi/simple/
-pip config list
+pip3 config set global.index-url https://azurebatch.pkgs.visualstudio.com/_packaging/BatchExplorer/pypi/simple/
+pip3 config list

--- a/.vsts/python-setup.yml
+++ b/.vsts/python-setup.yml
@@ -15,7 +15,7 @@ steps:
   - script: |
       set -e
       . "$(Agent.WorkFolder)/.venv/batchexplorer/bin/activate"
-      pip install -r desktop/python/requirements.txt
+      pip3 install -r desktop/python/requirements.txt
     condition: ne( variables['Agent.OS'], 'Windows_NT' )
     displayName: Install Python dependencies (Linux)
 
@@ -23,6 +23,6 @@ steps:
       . .vsts/win/exec.ps1
       $ErrorActionPreference = "Stop"
       $(Agent.WorkFolder)\.venv\batchexplorer\Scripts\Activate.ps1
-      exec { pip install -r desktop/python/requirements.txt }
+      exec { pip3 install -r desktop/python/requirements.txt }
     condition: eq( variables['Agent.OS'], 'Windows_NT' )
     displayName: Install Python dependencies (Windows)


### PR DESCRIPTION
This fixes an issue with the Mariner build container which doesn't provide python/pip on the path.