### PR TITLE
Add support for multiple repos to bux tooling

### DIFF
--- a/util/bux/cli.ts
+++ b/util/bux/cli.ts
@@ -82,10 +82,6 @@ yargs
                     type: "string",
                     describe: "The path to Batch Explorer/Shared Libraries",
                 })
-                .option("paths.batchPortalExtension", {
-                    type: "string",
-                    describe: "The path to the Batch portal extension",
-                })
                 .option("print", {
                     type: "boolean",
                     describe: "Print the resultant configuration object",


### PR DESCRIPTION
Add support for multiple repositories to be used with bux operations.

These changes allow for bux to be used as a tool to symlink JavaScript modules from BatchExplorer shared libraries packages with multiple repositories (namely, the Batch Portal and CycleCloud repos).

See this work item for more context: https://msazure.visualstudio.com/AzureBatch/_workitems/edit/27253286/

What the output looks like when running the commands in the portal:
```
PS C:\Users\sanjanakapur\Batch-UX-Portal> node_modules/.bin/bux configure
? Path to Batch Explorer (use /mnt/c/... for WSL, e.g., CycleCloud): C:\Users\sanjanakapur\BatchExplorer
Configuration saved to C:\Users\sanjanakapur\.config\batch\bux.json

PS C:\Users\sanjanakapur\Batch-UX-Portal> node_modules/.bin/bux status   
Batch Explorer (main)
  - Path: C:\Users\sanjanakapur\BatchExplorer
  - Staged changes:
      M  util/bux/cli.ts
      M  util/bux/util.ts

Link is inactive

PS C:\Users\sanjanakapur\Batch-UX-Portal> node_modules/.bin/bux link     
Linking @azure/bonito-core@1.0.1
Linking @azure/bonito-ui@1.0.1
Linking @batch/ui-playground@1.0.1
Linking @batch/ui-react@1.0.1
Linking @batch/ui-service@1.0.1

PS C:\Users\sanjanakapur\Batch-UX-Portal> node_modules/.bin/bux status
Batch Explorer (main)
  - Path: C:\Users\sanjanakapur\BatchExplorer
  - Staged changes:
      M  util/bux/cli.ts
      M  util/bux/util.ts

Link is active

PS C:\Users\sanjanakapur\Batch-UX-Portal> node_modules/.bin/bux unlink
Unlinking @azure/bonito-core@1.0.1
Unlinking @azure/bonito-ui@1.0.1
Unlinking @batch/ui-playground@1.0.1
Unlinking @batch/ui-react@1.0.1
Unlinking @batch/ui-service@1.0.1
Running `npm install` to restore packages...

PS C:\Users\sanjanakapur\Batch-UX-Portal>
```

What the output looks like when running commands in CycleCloud:

```
skapur@LAPTOP-T9HUH5SN:~/cc/cyclecloud$ node_modules/.bin/bux configure
? Path to Batch Explorer (use /mnt/c/... for WSL, e.g., CycleCloud): /mnt/c/Users/sanjanakapur/BatchExplorer
Configuration saved to /home/skapur/.config/batch/bux.json

skapur@LAPTOP-T9HUH5SN:~/cc/cyclecloud$ node_modules/.bin/bux status
Batch Explorer (main)
  - Path: /mnt/c/Users/sanjanakapur/BatchExplorer
  - Staged changes:
      M  util/bux/cli.ts
      M  util/bux/util.ts

Link is inactive

skapur@LAPTOP-T9HUH5SN:~/cc/cyclecloud$ node_modules/.bin/bux link
Linking @azure/bonito-core@1.0.1
Linking @azure/bonito-ui@1.0.1
skapur@LAPTOP-T9HUH5SN:~/cc/cyclecloud$ node_modules/.bin/bux status
Batch Explorer (main)
  - Path: /mnt/c/Users/sanjanakapur/BatchExplorer
  - Staged changes:
      M  util/bux/cli.ts
      M  util/bux/util.ts

Link is active

skapur@LAPTOP-T9HUH5SN:~/cc/cyclecloud$ node_modules/.bin/bux unlink
Unlinking @azure/bonito-core@1.0.1
Unlinking @azure/bonito-ui@1.0.1
Running `npm install` to restore packages...
lerna notice cli v8.1.2
lerna info Bootstrapping 2 packages
lerna info Symlinking packages and binaries
lerna info lifecycle @cyclecloud/pico@8.0.0-SNAPSHOT~postinstall: @cyclecloud/pico@8.0.0-SNAPSHOT

> @cyclecloud/pico@8.0.0-SNAPSHOT postinstall /home/skapur/cc/cyclecloud/gui/pico
> patch-package

patch-package 8.0.0
Applying patches...
dojo-webpack-plugin@3.0.5 ✔
lerna success Bootstrapped 2 packages

skapur@LAPTOP-T9HUH5SN:~/cc/cyclecloud$ 
```

