### PR TITLE
fix recover window failed to load in prod build

### DIFF
--- a/desktop/config/webpack.config.base.js
+++ b/desktop/config/webpack.config.base.js
@@ -56,7 +56,8 @@ const baseConfig = {
         }),
         new CopyWebpackPlugin({
             patterns: [
-                { context: "src/client/splash-screen", from: "**/*", to: "client/splash-screen" },
+                { context: "src/client/splash-screen", from: "**/*.(html|svg)", to: "client/splash-screen" },
+                { context: "src/client/recover-window", from: "**/*.(html|svg)", to: "client/recover-window" },
                 { context: "src/client/proxy", from: "**/*", to: "client/proxy" },
                 { context: "src/client/resources", from: "**/*", to: "client/resources" },
                 { context: "src/app/assets", from: "**/*", to: "assets" },


### PR DESCRIPTION
Copy `src/client/recover-window/recover-window.html` into the build output directory to fix recover window fails to load in production build.